### PR TITLE
Slice 3: Move role assignment hierarchy from frontend to backend DDD

### DIFF
--- a/.claude/skills/branch-plan/SKILL.md
+++ b/.claude/skills/branch-plan/SKILL.md
@@ -6,19 +6,20 @@ disable-model-invocation: true
 
 # Branch Plan Skill
 
-Create a new git branch with an accompanying plan file for tracked, context-preserving work.
+Create an accompanying plan file for current or provided branch to track context-preserving work.
 
 ## Usage
 
 ```
-/branch-plan <branch-name>
+/branch-plan [<branch-name>]
 ```
 
-Example: `/branch-plan ray/refactor-backend-gateway`
+Example 1: `/branch-plan` — creates a plan for the current branch
+Example 2: `/branch-plan ray/refactor-backend-gateway` - creates a plan for a new branch
 
 ## What This Skill Does
 
-1. **Create git branch** with the provided name
+1. **Create git branch** with the provided name if branch name is provided
 2. **Create plan file** at `CLAUDE.<sanitized-branch-name>.md` (slashes become hyphens)
 3. **Update `CLAUDE.local.md`** to reference the new plan file
 4. **Seed the plan** with a template including the "keep up-to-date" requirement

--- a/CLAUDE.refactor-frontend-ddd[tests].md
+++ b/CLAUDE.refactor-frontend-ddd[tests].md
@@ -93,11 +93,18 @@ Two levels of testing — domain policy (business rules) and service (orchestrat
 - **Add to**: `spec/application/services/attendances/record_attendance_spec.rb`
 - **Test scenarios**: Reject same account+event, informative error message, allow different events
 
-### Slice 3: Assignable Roles
+### Slice 3: Assignable Roles ✅
 
-- **New file**: `spec/application/services/enrollments/get_assignable_roles_spec.rb`
-- **Add route test to**: `spec/routes/course_route_spec.rb`
-- **Test scenarios**: Owner sees all assignable roles (not owner), instructor sees staff+student, student sees empty, non-enrolled gets forbidden
+- **Domain policy spec**: `spec/domain/courses/policies/role_assignment_spec.rb` (9 tests)
+  - `assignable_roles`: owner→all 4, instructor→staff+student, staff→student, student→empty, unknown→UnknownRoleError
+  - `for_enrollment`: uses highest role, handles multi-role and empty roles
+  - HIERARCHY constant test
+- **Service spec**: `spec/application/services/courses/get_assignable_roles_spec.rb` (6 tests)
+  - owner/instructor/staff/student permissions, non-enrolled→403, invalid course→404
+- **Route tests**: added to `spec/routes/course_route_spec.rb` (3 tests)
+  - owner→all roles, instructor→staff+student, non-enrolled→403
+- **Design decision**: Owner CAN assign owner role (matches current frontend; no DB constraint on multiple owners)
+- **Manual verification** (3.5): Confirmed via browser (owner sees 4-role dropdown) and API curl tests (owner→4 roles, instructor→staff+student, student→empty, non-enrolled→403, invalid course→404)
 
 ### Slice 4: Attendance Report
 
@@ -140,4 +147,4 @@ E2E tests will be added if manual verification proves insufficient. Candidates:
 
 ---
 
-*Last updated: 2026-02-07*
+*Last updated: 2026-02-08*

--- a/backend_app/app/application/controllers/routes/course.rb
+++ b/backend_app/app/application/controllers/routes/course.rb
@@ -33,6 +33,20 @@ module Tyto
 
           r.on String do |course_id|
 
+            r.on 'assignable_roles' do
+              # GET api/course/:course_id/assignable_roles
+              r.get do
+                case Service::Courses::GetAssignableRoles.new.call(requestor:, course_id:)
+                in Success(api_result)
+                  response.status = api_result.http_status_code
+                  { success: true, data: api_result.message }.to_json
+                in Failure(api_result)
+                  response.status = api_result.http_status_code
+                  api_result.to_json
+                end
+              end
+            end
+
             r.on 'enroll' do
               r.on String do |account_id|
                 # POST api/course/:course_id/enroll/:enroll_id

--- a/backend_app/app/application/services/courses/get_assignable_roles.rb
+++ b/backend_app/app/application/services/courses/get_assignable_roles.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require_relative '../../../infrastructure/database/repositories/courses'
+require_relative '../application_operation'
+
+module Tyto
+  module Service
+    module Courses
+      # Service: Get assignable roles for the requestor in a course
+      # Returns Success(ApiResult) with list of role strings the requestor can assign,
+      # or Failure(ApiResult) with error
+      class GetAssignableRoles < ApplicationOperation
+        def initialize(courses_repo: Repository::Courses.new)
+          @courses_repo = courses_repo
+          super()
+        end
+
+        def call(requestor:, course_id:)
+          course_id = step validate_course_id(course_id)
+          step find_course(course_id)
+          enrollment = step authorize(requestor, course_id)
+          roles = Policy::RoleAssignment.for_enrollment(enrollment.roles)
+
+          ok(roles)
+        end
+
+        private
+
+        def validate_course_id(course_id)
+          id = course_id.to_i
+          return Failure(bad_request('Invalid course ID')) if id.zero?
+
+          Success(id)
+        end
+
+        def find_course(course_id)
+          course = Course.first(id: course_id)
+          return Failure(not_found('Course not found')) unless course
+
+          Success(course)
+        end
+
+        def authorize(requestor, course_id)
+          enrollment = @courses_repo.find_enrollment(account_id: requestor.account_id, course_id:)
+          policy = Tyto::CoursePolicy.new(requestor, enrollment)
+
+          return Failure(forbidden('You have no access to this course')) unless policy.can_view?
+
+          Success(enrollment)
+        end
+      end
+    end
+  end
+end

--- a/backend_app/app/domain/courses/policies/role_assignment.rb
+++ b/backend_app/app/domain/courses/policies/role_assignment.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Tyto
+  module Policy
+    # Domain policy: "Which course roles can a given role assign?"
+    # Actor-agnostic — a domain expert would articulate this hierarchy
+    # without mentioning requestors or application context.
+    class RoleAssignment
+      UnknownRoleError = Class.new(StandardError)
+
+      HIERARCHY = %w[owner instructor staff student].freeze
+
+      ASSIGNABLE = {
+        'owner' => %w[owner instructor staff student],
+        'instructor' => %w[staff student],
+        'staff' => %w[student],
+        'student' => []
+      }.freeze
+
+      # Given a single role, return the roles it can assign.
+      # @param role [String] a course role name
+      # @return [Array<String>] assignable role names
+      # @raise [UnknownRoleError] if role is not a valid course role
+      def self.assignable_roles(role)
+        ASSIGNABLE.fetch(role) { raise UnknownRoleError, "Unknown course role: '#{role}'" }
+      end
+
+      # Given a CourseRoles collection, return assignable roles
+      # based on the highest role in the hierarchy.
+      # @param course_roles [CourseRoles] the enrollment's roles
+      # @return [Array<String>] assignable role names
+      def self.for_enrollment(course_roles)
+        highest = HIERARCHY.find { |role| course_roles.has?(role) }
+        return [] unless highest
+
+        assignable_roles(highest)
+      end
+    end
+  end
+end

--- a/backend_app/app/domain/courses/values/course_roles.rb
+++ b/backend_app/app/domain/courses/values/course_roles.rb
@@ -7,8 +7,9 @@ module Tyto
   module Domain
     module Courses
       module Values
-        # Value object representing a collection of course-level roles.
-        # Encapsulates role checking logic for Enrollment.
+        # Value object representing a specific person's collection of course-level roles.
+        # Answers "what roles does this person have?" — not about roles in general.
+        # For role hierarchy rules (e.g., which roles can assign which), see Policy::RoleAssignment.
         class CourseRoles < Dry::Struct
           attribute :roles, Types::Array.of(Types::CourseRole)
 

--- a/backend_app/spec/application/services/courses/get_assignable_roles_spec.rb
+++ b/backend_app/spec/application/services/courses/get_assignable_roles_spec.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+
+describe 'Service::Courses::GetAssignableRoles' do
+  include TestHelpers
+
+  def create_test_course(owner_account, name: 'Test Course')
+    course = Tyto::Course.create(name: name)
+    owner_role = Tyto::Role.find(name: 'owner')
+    Tyto::AccountCourse.create(
+      course_id: course.id,
+      account_id: owner_account.id,
+      role_id: owner_role.id
+    )
+    course
+  end
+
+  def enroll_as(account, course, role_name)
+    role = Tyto::Role.find(name: role_name)
+    Tyto::AccountCourse.create(
+      course_id: course.id,
+      account_id: account.id,
+      role_id: role.id
+    )
+  end
+
+  def requestor_for(account)
+    roles = account.roles.map(&:name)
+    Tyto::Domain::Accounts::Values::AuthCapability.new(
+      account_id: account.id, roles: roles
+    )
+  end
+
+  # 3.1a: Owner permission tests
+  describe 'owner permissions' do
+    it 'returns all four course roles for owner' do
+      owner = create_test_account(roles: ['creator'])
+      course = create_test_course(owner)
+
+      result = Tyto::Service::Courses::GetAssignableRoles.new.call(
+        requestor: requestor_for(owner), course_id: course.id
+      )
+
+      _(result).must_be_kind_of Dry::Monads::Result::Success
+      assignable = result.value!.message
+      _(assignable).must_include 'owner'
+      _(assignable).must_include 'instructor'
+      _(assignable).must_include 'staff'
+      _(assignable).must_include 'student'
+      _(assignable.length).must_equal 4
+    end
+  end
+
+  # 3.1b: Instructor permission tests
+  describe 'instructor permissions' do
+    it 'returns staff and student for instructor' do
+      owner = create_test_account(roles: ['creator'])
+      course = create_test_course(owner)
+      instructor = create_test_account(roles: ['member'])
+      enroll_as(instructor, course, 'instructor')
+
+      result = Tyto::Service::Courses::GetAssignableRoles.new.call(
+        requestor: requestor_for(instructor), course_id: course.id
+      )
+
+      _(result).must_be_kind_of Dry::Monads::Result::Success
+      assignable = result.value!.message
+      _(assignable).must_include 'staff'
+      _(assignable).must_include 'student'
+      _(assignable).wont_include 'owner'
+      _(assignable).wont_include 'instructor'
+      _(assignable.length).must_equal 2
+    end
+  end
+
+  # 3.1c: Student and non-enrolled permission tests
+  describe 'student permissions' do
+    it 'returns empty array for student' do
+      owner = create_test_account(roles: ['creator'])
+      course = create_test_course(owner)
+      student = create_test_account(roles: ['member'])
+      enroll_as(student, course, 'student')
+
+      result = Tyto::Service::Courses::GetAssignableRoles.new.call(
+        requestor: requestor_for(student), course_id: course.id
+      )
+
+      _(result).must_be_kind_of Dry::Monads::Result::Success
+      assignable = result.value!.message
+      _(assignable).must_be_kind_of Array
+      _(assignable).must_be_empty
+    end
+  end
+
+  describe 'staff permissions' do
+    it 'returns student for staff' do
+      owner = create_test_account(roles: ['creator'])
+      course = create_test_course(owner)
+      staff_member = create_test_account(roles: ['member'])
+      enroll_as(staff_member, course, 'staff')
+
+      result = Tyto::Service::Courses::GetAssignableRoles.new.call(
+        requestor: requestor_for(staff_member), course_id: course.id
+      )
+
+      _(result).must_be_kind_of Dry::Monads::Result::Success
+      assignable = result.value!.message
+      _(assignable).must_equal ['student']
+    end
+  end
+
+  describe 'non-enrolled user' do
+    it 'returns forbidden for non-enrolled user' do
+      owner = create_test_account(roles: ['creator'])
+      course = create_test_course(owner)
+      outsider = create_test_account(roles: ['member'])
+
+      result = Tyto::Service::Courses::GetAssignableRoles.new.call(
+        requestor: requestor_for(outsider), course_id: course.id
+      )
+
+      _(result).must_be_kind_of Dry::Monads::Result::Failure
+      _(result.failure.status).must_equal :forbidden
+    end
+  end
+
+  describe 'invalid course' do
+    it 'returns not_found for nonexistent course' do
+      account = create_test_account(roles: ['creator'])
+
+      result = Tyto::Service::Courses::GetAssignableRoles.new.call(
+        requestor: requestor_for(account), course_id: 99999
+      )
+
+      _(result).must_be_kind_of Dry::Monads::Result::Failure
+      _(result.failure.status).must_equal :not_found
+    end
+  end
+end

--- a/backend_app/spec/domain/courses/policies/role_assignment_spec.rb
+++ b/backend_app/spec/domain/courses/policies/role_assignment_spec.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require_relative '../../../spec_helper'
+
+describe 'Tyto::Policy::RoleAssignment' do
+  describe '.assignable_roles' do
+    it 'returns all course roles for owner' do
+      result = Tyto::Policy::RoleAssignment.assignable_roles('owner')
+
+      _(result).must_equal %w[owner instructor staff student]
+    end
+
+    it 'returns staff and student for instructor' do
+      result = Tyto::Policy::RoleAssignment.assignable_roles('instructor')
+
+      _(result).must_equal %w[staff student]
+    end
+
+    it 'returns student for staff' do
+      result = Tyto::Policy::RoleAssignment.assignable_roles('staff')
+
+      _(result).must_equal %w[student]
+    end
+
+    it 'returns empty array for student' do
+      result = Tyto::Policy::RoleAssignment.assignable_roles('student')
+
+      _(result).must_equal []
+    end
+
+    it 'raises UnknownRoleError for unknown role' do
+      _(-> { Tyto::Policy::RoleAssignment.assignable_roles('unknown') })
+        .must_raise Tyto::Policy::RoleAssignment::UnknownRoleError
+    end
+  end
+
+  describe '.for_enrollment' do
+    it 'uses highest role from enrollment' do
+      roles = Tyto::Domain::Courses::Values::CourseRoles.from(%w[instructor student])
+
+      result = Tyto::Policy::RoleAssignment.for_enrollment(roles)
+
+      _(result).must_equal %w[staff student]
+    end
+
+    it 'returns all roles when enrollment includes owner' do
+      roles = Tyto::Domain::Courses::Values::CourseRoles.from(%w[owner instructor])
+
+      result = Tyto::Policy::RoleAssignment.for_enrollment(roles)
+
+      _(result).must_equal %w[owner instructor staff student]
+    end
+
+    it 'returns empty array for empty roles' do
+      roles = Tyto::Domain::Courses::Values::CourseRoles.from([])
+
+      result = Tyto::Policy::RoleAssignment.for_enrollment(roles)
+
+      _(result).must_equal []
+    end
+  end
+
+  describe 'HIERARCHY' do
+    it 'defines four course roles in descending order' do
+      _(Tyto::Policy::RoleAssignment::HIERARCHY).must_equal %w[owner instructor staff student]
+    end
+  end
+end

--- a/frontend_app/pages/course/SingleCourse.vue
+++ b/frontend_app/pages/course/SingleCourse.vue
@@ -18,7 +18,7 @@
                   :course="course"
                   :attendance-events="attendanceEvents" :locations="locations" @create-event="showAttendanceEvent" @edit-event="editAttendanceEvent" @delete-event="deleteAttendanceEvent"
                   @create-location="createNewLocation" @update-location="updateLocation" @delete-location="deleteLocation"
-                  :enrollments="enrollments" @new-enrolls="addEnrollments" @update-enrollment="updateEnrollment" @delete-enrollment="deleteEnrollments" :currentRole="currentRole"
+                  :enrollments="enrollments" :assignableRoles="assignableRoles" @new-enrolls="addEnrollments" @update-enrollment="updateEnrollment" @delete-enrollment="deleteEnrollments" :currentRole="currentRole"
                 >
                 </RouterView>
               </div>
@@ -135,6 +135,7 @@ export default {
       showModifyAttendanceEventDialog: false,
       isAddedValue: false,
       enrollments: [],
+      assignableRoles: [],
       currentEventID: '',
       activeTab: 'events'
     };
@@ -160,6 +161,7 @@ export default {
         this.fetchAttendanceEvents(this.course.id);
         this.fetchLocations();
         this.fetchEnrollments();
+        this.fetchAssignableRoles();
       }
     }
   },
@@ -225,6 +227,13 @@ export default {
         this.fetchCourse(this.course.id);
       }).catch(error => {
         console.error('Error creating course:', error);
+      });
+    },
+    fetchAssignableRoles() {
+      api.get(`/course/${this.course.id}/assignable_roles`).then(response => {
+        this.assignableRoles = response.data.data;
+      }).catch(error => {
+        console.error('Error fetching assignable roles:', error);
       });
     },
     fetchEnrollments() {

--- a/frontend_app/pages/course/components/ManagePeopleCard.vue
+++ b/frontend_app/pages/course/components/ManagePeopleCard.vue
@@ -53,7 +53,7 @@
           </el-form-item>
           <el-form-item label="Roles">
             <el-select v-model="selectedAccount.enroll_identity" placeholder="Select role" multiple style="width:95%;">
-              <el-option v-for="role in peopleRoleList" :key="role" :label="role" :value="role" :disabled="checkIsModifable(role)"></el-option>
+              <el-option v-for="role in assignableRoles" :key="role" :label="role" :value="role"></el-option>
             </el-select>
           </el-form-item>
       </el-form>
@@ -72,8 +72,12 @@ export default {
   props: {
     attendanceEvents: Object,
     locations: Array,
-    enrollments: Object, 
-    currentRole: String
+    enrollments: Object,
+    currentRole: String,
+    assignableRoles: {
+      type: Array,
+      default: () => []
+    }
   },
   data() {
     return {
@@ -81,12 +85,6 @@ export default {
       newEnrollmentEmails: '',
       newEnrolls: [],
       enrollStep: 1,
-      peopleform: {
-        owner: ['owner', 'instructor', 'staff', 'student'],
-        instructor: ['staff', 'student'],
-        staff: ['student']
-      },
-      peopleRoleList: ['owner', 'instructor', 'staff', 'student'],
       editDialogVisible: false,
       selectedAccount: {}
     }
@@ -108,10 +106,6 @@ export default {
       this.selectedAccount = JSON.parse(JSON.stringify(account))
       
       this.editDialogVisible = true;
-    },
-    checkIsModifable(role) {
-      const availableRoles = this.peopleform[this.currentRole]
-      return !availableRoles.includes(role)
     },
     onDialogClose() {
       this.$emit('dialog-closed')


### PR DESCRIPTION
## Summary

- **Slice 3** of the frontend-to-backend DDD refactoring ([plan](CLAUDE.refactor-frontend-ddd.md))
- Replaces hardcoded frontend role hierarchy in `ManagePeopleCard.vue` with a new backend API endpoint that computes assignable roles based on the requestor's enrollment
- Adds domain policy, application service, route, and 18 new tests

## Problem

The frontend had a hardcoded `peopleform` mapping that determined which roles each role could assign:
```js
peopleform: {
  owner: ['owner', 'instructor', 'staff', 'student'],
  instructor: ['staff', 'student'],
  staff: ['student']
}
```
This duplicated business logic that belongs in the backend domain layer, and could drift out of sync with actual authorization rules.

## Solution

### Backend (DDD architecture)

**Domain policy** — `Policy::RoleAssignment` (`app/domain/courses/policies/role_assignment.rb`)
- Actor-agnostic business rule: "which roles can a given role assign?"
- Owns `HIERARCHY` and `ASSIGNABLE` constants
- Two entry points: `assignable_roles(role)` for a single role, `for_enrollment(course_roles)` for a CourseRoles value object (uses highest role)
- Raises `UnknownRoleError` for invalid roles

**Application service** — `Service::Courses::GetAssignableRoles`
- Thin orchestrator: validate course_id → find course → authorize (enrolled?) → delegate to domain policy
- Railway-oriented (Dry::Monads), consistent with existing services

**Route** — `GET /api/course/:id/assignable_roles`
- Returns `{ success: true, data: ["owner", "instructor", "staff", "student"] }`

### Frontend

- `SingleCourse.vue` fetches assignable roles from API on role change, passes as `assignableRoles` prop
- `ManagePeopleCard.vue` receives `assignableRoles` prop; removed hardcoded `peopleform`, `peopleRoleList`, and `checkIsModifable` method
- Role dropdown in Edit dialog now iterates over API-provided roles (no disabled options — only assignable roles appear)

### Role hierarchy

| Requestor role | Can assign |
|----------------|------------|
| owner | owner, instructor, staff, student |
| instructor | staff, student |
| staff | student |
| student | _(empty)_ |
| non-enrolled | 403 Forbidden |

**Design decision**: Owner CAN assign the owner role (matches prior frontend behavior; no DB constraint on multiple owners per course).

## Test plan

- [x] Domain policy spec — 9 tests (`spec/domain/courses/policies/role_assignment_spec.rb`)
  - `assignable_roles`: owner→all 4, instructor→staff+student, staff→student, student→empty, unknown→error
  - `for_enrollment`: uses highest role, handles multi-role and empty roles
- [x] Service spec — 6 tests (`spec/application/services/courses/get_assignable_roles_spec.rb`)
  - owner/instructor/staff/student permissions, non-enrolled→403, invalid course→404
- [x] Route integration — 3 tests (`spec/routes/course_route_spec.rb`)
  - owner→all roles, instructor→staff+student, non-enrolled→403
- [x] Manual verification — browser (owner sees 4-role dropdown) and API curl tests (all 5 role scenarios)
- [x] Full test suite passes: 749 tests, 0 failures, 97.94% coverage