### PR TITLE
fix(build,web): bust stale frontend cache on deploys

### DIFF
--- a/backend_app/app/application/controllers/app.rb
+++ b/backend_app/app/application/controllers/app.rb
@@ -63,10 +63,12 @@ module Tyto
       end
 
       r.root do
+        response['Cache-Control'] = 'no-cache'
         File.read(File.join('dist', 'index.html'))
       end
 
       r.get [String, true], [String, true], [String, true], [true] do |_parsed_request|
+        response['Cache-Control'] = 'no-cache'
         File.read(File.join('dist', 'index.html'))
       end
     end

--- a/backend_app/db/seeds/store/readme.txt
+++ b/backend_app/db/seeds/store/readme.txt
@@ -1,0 +1,1 @@
+Local dev/test databases go in this folder

--- a/backend_app/spec/routes/index_html_cache_spec.rb
+++ b/backend_app/spec/routes/index_html_cache_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require_relative '../spec_helper'
+
+describe 'Index HTML caching' do
+  include Rack::Test::Methods
+  include TestHelpers
+
+  def app
+    Tyto::Api
+  end
+
+  it 'serves index.html with Cache-Control: no-cache on root' do
+    File.stub :read, '<html></html>' do
+      get '/'
+    end
+    _(last_response.status).must_equal 200
+    _(last_response.headers['Cache-Control']).must_equal 'no-cache'
+  end
+
+  it 'serves index.html with Cache-Control: no-cache on SPA fallback' do
+    File.stub :read, '<html></html>' do
+      get '/some/deep/link'
+    end
+    _(last_response.status).must_equal 200
+    _(last_response.headers['Cache-Control']).must_equal 'no-cache'
+  end
+end

--- a/webpack/webpack.prod.js
+++ b/webpack/webpack.prod.js
@@ -4,7 +4,12 @@ const common = require('./webpack.common');
 //Configure prod enviroment by using common configuration and adding some more options
 module.exports = merge(common, {
     mode: 'production',
-    devtool: false
-    //we can add many of optimizations configurations as minification, compression and so on, 
+    devtool: false,
+    // Content-hashed filenames so each deploy produces a unique bundle URL,
+    // bypassing browser caches without relying on Cache-Control on the bundle itself.
+    output: {
+        filename: '[name].[contenthash].bundle.js'
+    }
+    //we can add many of optimizations configurations as minification, compression and so on,
     //but to be a minumal project exemple so its needs to have only minimal configuration
 })


### PR DESCRIPTION
## Summary

Follow-up to #61. After that PR shipped, the timezone fix didn't take effect until browsers either hard-refreshed or let heuristic cache freshness lapse — because `main.bundle.js` has a stable URL with only `Last-Modified` and no `Cache-Control`. This PR makes future frontend deploys propagate immediately.

## Problem

- `webpack.prod.js` emitted `main.bundle.js` — stable name, no content hash
- Roda's `r.public` and the `index.html` responses sent no `Cache-Control`
- Browsers cached the bundle under heuristic freshness; users kept running old JS after deploy

## Fix (two halves together)

- **`webpack.prod.js`**: `output.filename: '[name].[contenthash].bundle.js'` — each content change produces a new URL, guaranteed cache miss. `HtmlWebpackPlugin` already injects the hashed name into `index.html`.
- **`app.rb`**: `Cache-Control: no-cache` on both `index.html` responses (root + SPA fallback) so the referrer HTML always revalidates and picks up the new bundle name on the next navigation.

Either alone isn't enough: content hashes don't help if the stale `index.html` still references the old bundle; `no-cache` on HTML doesn't help if the bundle URL never changes. Both together make deploys propagate on first navigation.

## Other

- `backend_app/db/seeds/store/readme.txt` tracked so the folder is recreated on clone (`*.db` remains gitignored).

## Test plan

- [x] New `index_html_cache_spec`: 2 tests covering root and SPA fallback paths
- [x] Full backend suite: 907 runs, 0 failures, 0 errors
- [x] `npm run prod` locally produced `main.e61bac0a63b01b6827dd.bundle.js` and `dist/index.html` references it