### PR TITLE
test(e2e): browser-based e2e suite with page object model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,3 +64,55 @@ jobs:
 
       - name: Run frontend tests
         run: npm test
+
+  e2e-tests:
+    # Browser-based E2E (Playwright). Needs both Ruby (API + rake) and Node
+    # (build + Playwright). `rake spec:e2e` resets+seeds the test DB, builds the
+    # SPA, and runs the specs against a backend it boots itself on :9292.
+    runs-on: ubuntu-latest
+
+    env:
+      BUNDLE_WITHOUT: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install libsodium
+        run: sudo apt-get update && sudo apt-get install -y libsodium-dev
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: .ruby-version
+          bundler-cache: true
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install frontend dependencies
+        run: npm ci
+
+      - name: Create test secrets
+        run: |
+          set -o pipefail
+          JWT_KEY=$(bundle exec rake generate:jwt_key | grep 'JWT_KEY:' | cut -d' ' -f2)
+          SIGNING_KEY=$(bundle exec rake generate:local_storage_signing_key | grep 'LOCAL_STORAGE_SIGNING_KEY:' | cut -d' ' -f2)
+          mkdir -p backend_app/tmp/local_storage_test
+          printf "test:\n  DATABASE_URL: sqlite://backend_app/db/store/test.db\n  JWT_KEY: %s\n  ADMIN_EMAIL: test@example.com\n  LOCAL_STORAGE_ROOT: backend_app/tmp/local_storage_test\n  LOCAL_STORAGE_SIGNING_KEY: %s\n  LOCAL_STORAGE_BASE_URL: http://localhost:9292\n" "$JWT_KEY" "$SIGNING_KEY" > backend_app/config/secrets.yml
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E
+        run: bundle exec rake spec:e2e
+
+      - name: Upload Playwright report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,13 @@ dist/
 # temporary assets during development
 tmp/
 
+# Playwright E2E artifacts + minted credentials (never commit credentials)
+e2e/.auth/
+playwright-report/
+test-results/
+/blob-report/
+/playwright/.cache/
+
 # test/dev infrastructure
 *.db
 

--- a/README.md
+++ b/README.md
@@ -60,17 +60,30 @@ rake run:api
 
 ## Testing
 
+The project has three test layers:
+
+| Layer | Tool | What it covers | Command |
+| --- | --- | --- | --- |
+| Backend | Minitest | API routes, services, policies, domain | `bundle exec rake spec:backend` |
+| Frontend | Vitest | Vue components in isolation (jsdom) | `bundle exec rake spec:frontend` |
+| End-to-end | Playwright | Real browser driving the live app + API | `bundle exec rake spec:e2e` |
+
 ```shell
-bundle exec rake spec            # Run all tests, backend + frontend (default task)
+bundle exec rake spec            # Backend + frontend (default task) — does NOT run e2e
 bundle exec rake spec:backend    # Backend only (Minitest)
 bundle exec rake spec:frontend   # Frontend only (Vitest; same as npm test)
+bundle exec rake spec:e2e        # Browser end-to-end (Playwright); opt-in, self-contained
 ```
 
-Ensure the test database is set up first:
+Set up the test database before running backend or frontend specs:
 
 ```shell
 RACK_ENV=test bundle exec rake db:setup
 ```
+
+`spec:e2e` is opt-in (not part of `rake spec`) and manages its own test DB, seed, and
+frontend build. See **[Testing Guide](doc/testing.md)** for full setup and how the
+e2e harness works.
 
 Note: the backend suite reports one intentional skip (`courses_spec.rb` — testing a missing `owner` role would require deleting seed data the rest of the suite depends on).
 
@@ -86,6 +99,7 @@ bundle exec rake db:drop        # Delete database (destructive)
 
 ## Documentation
 
+- [Testing Guide](doc/testing.md) — Backend (Minitest), frontend (Vitest), and end-to-end (Playwright) tests
 - [Google OAuth Setup](doc/google.md) — Configure Google Cloud credentials
 - [Heroku Deployment](doc/heroku.md) — Deploy to production
 - [AWS S3 Setup](doc/s3.md) — Configure S3 bucket, IAM, and CORS for file uploads (production)

--- a/Rakefile
+++ b/Rakefile
@@ -14,6 +14,18 @@ namespace :spec do
   task :frontend do
     sh 'npm test'
   end
+
+  desc 'Run browser-based E2E (Playwright). Resets+seeds the test DB, builds the frontend, then runs specs against :9292.'
+  task :e2e do
+    # Separate processes on purpose: `db:reset` in one process is broken for
+    # SQLite. See .claude/plans/PLAN.test-ui.md "DB reset footgun".
+    sh 'RACK_ENV=test bundle exec rake db:drop'
+    sh 'RACK_ENV=test bundle exec rake db:migrate'
+    sh 'RACK_ENV=test bundle exec rake db:seed'
+
+    sh 'npm run prod'
+    sh 'npx playwright test'
+  end
 end
 
 desc 'Run all tests (backend + frontend)'
@@ -155,5 +167,57 @@ namespace :generate do
   task :local_storage_signing_key do
     require_relative 'backend_app/app/lib/security'
     puts "LOCAL_STORAGE_SIGNING_KEY: #{Tyto::Security.generate_signing_key}"
+  end
+
+  desc 'Mint an auth credential for a seeded account (E2E login bypass). Usage: rake "generate:test_credential[email@example.com]"'
+  task :test_credential, [:email] do |_t, args|
+    require('json')
+    require_relative 'require_app'
+    require_app # full app + initializers so AuthToken::Gateway is configured
+
+    email = args[:email] or abort('Usage: rake "generate:test_credential[email@example.com]"')
+
+    account = Tyto::Repository::Accounts.new.find_by_email_with_roles(email)
+    abort("No account found for email: #{email}") unless account
+
+    roles = account.roles.to_a
+    credential = Tyto::AuthToken::Mapper.new.from_credentials(account.id, roles)
+
+    # Emit a single JSON line so the Playwright login fixture can parse stdout.
+    puts JSON.generate(
+      id: account.id,
+      name: account.name,
+      email: account.email,
+      avatar: account.avatar,
+      roles: roles,
+      credential: credential
+    )
+  end
+
+  desc 'Mint credentials for every E2E account (@e2e.test) in one boot, keyed by role. Used by the Playwright E2E global setup.'
+  task :e2e_credentials do
+    require('json')
+    require_relative 'require_app'
+    require_app
+
+    mapper = Tyto::AuthToken::Mapper.new
+    accounts = Tyto::Account.where(Sequel.like(:email, '%@e2e.test')).all
+
+    by_role = accounts.each_with_object({}) do |orm, acc|
+      # 'e2e-owner@e2e.test' -> 'owner'
+      role_key = orm.email.split('@').first.sub(/\Ae2e-/, '')
+      roles = orm.roles.map(&:name)
+      acc[role_key] = {
+        id: orm.id,
+        name: orm.name,
+        email: orm.email,
+        avatar: orm.avatar,
+        roles: roles,
+        credential: mapper.from_credentials(orm.id, roles)
+      }
+    end
+
+    # Single JSON object on stdout: { "owner": {...}, "student": {...}, ... }
+    puts JSON.generate(by_role)
   end
 end

--- a/Rakefile
+++ b/Rakefile
@@ -220,4 +220,14 @@ namespace :generate do
     # Single JSON object on stdout: { "owner": {...}, "student": {...}, ... }
     puts JSON.generate(by_role)
   end
+
+  desc 'Emit E2E seed-reference data (course/location/event names + coords, account emails) as JSON for the Playwright specs. Pure data — no app boot, no DB.'
+  task :e2e_seed_data do
+    require('json')
+    require_relative 'backend_app/db/seeds/e2e_fixtures'
+
+    # Single JSON object on stdout, consumed by e2e/seed-data.mjs. Mirrors the
+    # seed fixtures so specs and the seeded DB never drift.
+    puts JSON.generate(Tyto::E2EFixtures.as_json)
+  end
 end

--- a/backend_app/db/seeds/account_seeds.rb
+++ b/backend_app/db/seeds/account_seeds.rb
@@ -44,7 +44,13 @@ Tyto::Account.add_account(admin_user_data)
 # The fixture *data* (accounts, course name, locations, event) lives in the pure
 # `Tyto::E2EFixtures` module so the Playwright specs can import the same values
 # (via `rake generate:e2e_seed_data`) and never drift from what is seeded here.
+#
+# DEV + TEST ONLY — never seed these deterministic fixtures into production,
+# where they would pollute real data. Roles + the admin account above still
+# seed in every environment.
 # ---------------------------------------------------------------------------
+
+return if Tyto::Api.environment == :production
 
 fx = Tyto::E2EFixtures
 E2E_COURSE_NAME = fx::COURSE_NAME

--- a/backend_app/db/seeds/account_seeds.rb
+++ b/backend_app/db/seeds/account_seeds.rb
@@ -6,6 +6,7 @@ require_relative '../../app/infrastructure/database/orm/course'
 require_relative '../../app/infrastructure/database/orm/account_course'
 require_relative '../../app/infrastructure/database/orm/location'
 require_relative '../../app/infrastructure/database/orm/event'
+require_relative 'e2e_fixtures'
 
 # Define the role descriptions
 role_descriptions = ['admin', 'creator', 'member', 'owner', 'instructor', 'staff', 'student']
@@ -39,34 +40,18 @@ Tyto::Account.add_account(admin_user_data)
 # Emails use the reserved-for-tests `e2e.test` domain so they can never collide
 # with a real Google account. Mint a login credential for any of these with:
 #   RACK_ENV=test bundle exec rake "generate:test_credential[e2e-owner@e2e.test]"
+#
+# The fixture *data* (accounts, course name, locations, event) lives in the pure
+# `Tyto::E2EFixtures` module so the Playwright specs can import the same values
+# (via `rake generate:e2e_seed_data`) and never drift from what is seeded here.
 # ---------------------------------------------------------------------------
 
-E2E_ACCOUNTS = {
-  admin:      { name: 'E2E Admin',      email: 'e2e-admin@e2e.test',      system_roles: %w[admin creator member] },
-  creator:    { name: 'E2E Creator',    email: 'e2e-creator@e2e.test',    system_roles: %w[creator member] },
-  owner:      { name: 'E2E Owner',      email: 'e2e-owner@e2e.test',      system_roles: %w[member] },
-  instructor: { name: 'E2E Instructor', email: 'e2e-instructor@e2e.test', system_roles: %w[member] },
-  staff:      { name: 'E2E Staff',      email: 'e2e-staff@e2e.test',      system_roles: %w[member] },
-  student:    { name: 'E2E Student',    email: 'e2e-student@e2e.test',    system_roles: %w[member] },
-  # Enrolled with TWO course roles so the SingleCourse "view as role" switcher
-  # has more than one option to switch between (task 8a).
-  multi:      { name: 'E2E Multi-role', email: 'e2e-multi@e2e.test',      system_roles: %w[member] }
-}.freeze
+fx = Tyto::E2EFixtures
+E2E_COURSE_NAME = fx::COURSE_NAME
+E2E_LOCATION = fx::MAIN_HALL
+E2E_EVENT_NAME = fx::EVENT_NAME
 
-# Per-course enrollment: account key => course role(s). admin + creator stay
-# unenrolled so specs have a "not a member of this course" actor to assert on.
-E2E_COURSE_ENROLLMENTS = {
-  owner: %w[owner],
-  instructor: %w[instructor],
-  staff: %w[staff],
-  student: %w[student],
-  multi: %w[instructor student]
-}.freeze
-E2E_COURSE_NAME = 'E2E Course'
-E2E_LOCATION = { name: 'E2E Main Hall', latitude: 25.0330, longitude: 121.5654 }.freeze
-E2E_EVENT_NAME = 'E2E Live Session'
-
-e2e_accounts = E2E_ACCOUNTS.transform_values do |spec|
+e2e_accounts = fx::ACCOUNTS.transform_values do |spec|
   # A non-blank avatar so App.vue renders the avatar popover (and its Logout
   # control) — the UI path E2E specs click. The URL need not resolve.
   avatar = "https://e2e.test/avatar/#{spec[:email].split('@').first}.png"
@@ -83,7 +68,7 @@ end
 e2e_course = Tyto::Course.first(name: E2E_COURSE_NAME) ||
              Tyto::Course.create(name: E2E_COURSE_NAME, account_id: e2e_accounts[:owner].id)
 
-E2E_COURSE_ENROLLMENTS.each do |account_key, role_names|
+fx::COURSE_ENROLLMENTS.each do |account_key, role_names|
   account = e2e_accounts[account_key]
   role_names.each do |role_name|
     role = Tyto::Role.first(name: role_name)
@@ -104,8 +89,13 @@ e2e_location = Tyto::Location.first(course_id: e2e_course.id, name: E2E_LOCATION
 
 # A second, event-free location the Locations spec can delete (task 14). Kept
 # separate from E2E Main Hall so deleting it never cascades the seeded event.
-unless Tyto::Location.first(course_id: e2e_course.id, name: 'E2E Spare Room')
-  Tyto::Location.create(course_id: e2e_course.id, name: 'E2E Spare Room', latitude: 25.0340, longitude: 121.5660)
+unless Tyto::Location.first(course_id: e2e_course.id, name: fx::SPARE_ROOM[:name])
+  Tyto::Location.create(
+    course_id: e2e_course.id,
+    name: fx::SPARE_ROOM[:name],
+    latitude: fx::SPARE_ROOM[:latitude],
+    longitude: fx::SPARE_ROOM[:longitude]
+  )
 end
 
 # An attendance event whose window spans "now" (±1 day) so the student always

--- a/backend_app/db/seeds/account_seeds.rb
+++ b/backend_app/db/seeds/account_seeds.rb
@@ -2,6 +2,10 @@
 
 require_relative '../../app/infrastructure/database/orm/role'
 require_relative '../../app/infrastructure/database/orm/account'
+require_relative '../../app/infrastructure/database/orm/course'
+require_relative '../../app/infrastructure/database/orm/account_course'
+require_relative '../../app/infrastructure/database/orm/location'
+require_relative '../../app/infrastructure/database/orm/event'
 
 # Define the role descriptions
 role_descriptions = ['admin', 'creator', 'member', 'owner', 'instructor', 'staff', 'student']
@@ -21,3 +25,102 @@ admin_user_data = {
 
 # Add a new account with the provided data
 Tyto::Account.add_account(admin_user_data)
+
+# ---------------------------------------------------------------------------
+# E2E fixtures (browser-based user-acceptance tests)
+#
+# Deterministic accounts + one fully-enrolled course so Playwright specs can
+# log in (via cookie injection) as each system role and each per-course
+# enrollment role. Idempotent: safe to re-run against an already-seeded DB.
+#
+#   System roles  (admin/creator/member)      -> carried in the JWT credential
+#   Course roles  (owner/instructor/staff/...) -> rows in account_course_roles
+#
+# Emails use the reserved-for-tests `e2e.test` domain so they can never collide
+# with a real Google account. Mint a login credential for any of these with:
+#   RACK_ENV=test bundle exec rake "generate:test_credential[e2e-owner@e2e.test]"
+# ---------------------------------------------------------------------------
+
+E2E_ACCOUNTS = {
+  admin:      { name: 'E2E Admin',      email: 'e2e-admin@e2e.test',      system_roles: %w[admin creator member] },
+  creator:    { name: 'E2E Creator',    email: 'e2e-creator@e2e.test',    system_roles: %w[creator member] },
+  owner:      { name: 'E2E Owner',      email: 'e2e-owner@e2e.test',      system_roles: %w[member] },
+  instructor: { name: 'E2E Instructor', email: 'e2e-instructor@e2e.test', system_roles: %w[member] },
+  staff:      { name: 'E2E Staff',      email: 'e2e-staff@e2e.test',      system_roles: %w[member] },
+  student:    { name: 'E2E Student',    email: 'e2e-student@e2e.test',    system_roles: %w[member] },
+  # Enrolled with TWO course roles so the SingleCourse "view as role" switcher
+  # has more than one option to switch between (task 8a).
+  multi:      { name: 'E2E Multi-role', email: 'e2e-multi@e2e.test',      system_roles: %w[member] }
+}.freeze
+
+# Per-course enrollment: account key => course role(s). admin + creator stay
+# unenrolled so specs have a "not a member of this course" actor to assert on.
+E2E_COURSE_ENROLLMENTS = {
+  owner: %w[owner],
+  instructor: %w[instructor],
+  staff: %w[staff],
+  student: %w[student],
+  multi: %w[instructor student]
+}.freeze
+E2E_COURSE_NAME = 'E2E Course'
+E2E_LOCATION = { name: 'E2E Main Hall', latitude: 25.0330, longitude: 121.5654 }.freeze
+E2E_EVENT_NAME = 'E2E Live Session'
+
+e2e_accounts = E2E_ACCOUNTS.transform_values do |spec|
+  # A non-blank avatar so App.vue renders the avatar popover (and its Logout
+  # control) — the UI path E2E specs click. The URL need not resolve.
+  avatar = "https://e2e.test/avatar/#{spec[:email].split('@').first}.png"
+  account = Tyto::Account.first(email: spec[:email]) ||
+            Tyto::Account.create(name: spec[:name], email: spec[:email], avatar: avatar)
+  have = account.roles.map(&:name)
+  (spec[:system_roles] - have).each do |role_name|
+    role = Tyto::Role.first(name: role_name)
+    account.add_role(role) if role
+  end
+  account
+end
+
+e2e_course = Tyto::Course.first(name: E2E_COURSE_NAME) ||
+             Tyto::Course.create(name: E2E_COURSE_NAME, account_id: e2e_accounts[:owner].id)
+
+E2E_COURSE_ENROLLMENTS.each do |account_key, role_names|
+  account = e2e_accounts[account_key]
+  role_names.each do |role_name|
+    role = Tyto::Role.first(name: role_name)
+    next unless role
+
+    exists = Tyto::AccountCourse.first(account_id: account.id, course_id: e2e_course.id, role_id: role.id)
+    Tyto::AccountCourse.create(account_id: account.id, course_id: e2e_course.id, role_id: role.id) unless exists
+  end
+end
+
+e2e_location = Tyto::Location.first(course_id: e2e_course.id, name: E2E_LOCATION[:name]) ||
+               Tyto::Location.create(
+                 course_id: e2e_course.id,
+                 name: E2E_LOCATION[:name],
+                 latitude: E2E_LOCATION[:latitude],
+                 longitude: E2E_LOCATION[:longitude]
+               )
+
+# A second, event-free location the Locations spec can delete (task 14). Kept
+# separate from E2E Main Hall so deleting it never cascades the seeded event.
+unless Tyto::Location.first(course_id: e2e_course.id, name: 'E2E Spare Room')
+  Tyto::Location.create(course_id: e2e_course.id, name: 'E2E Spare Room', latitude: 25.0340, longitude: 121.5660)
+end
+
+# An attendance event whose window spans "now" (±1 day) so the student always
+# has something to check into during a E2E run (task 11 — geo-fence check-in).
+# Held at E2E Main Hall so its coordinates anchor the geo-fence.
+unless Tyto::Event.first(course_id: e2e_course.id, name: E2E_EVENT_NAME)
+  now = Time.now
+  one_day = 24 * 60 * 60
+  Tyto::Event.create(
+    course_id: e2e_course.id,
+    location_id: e2e_location.id,
+    name: E2E_EVENT_NAME,
+    start_at: now - one_day,
+    end_at: now + one_day
+  )
+end
+
+puts 'E2E fixtures seeded.'

--- a/backend_app/db/seeds/e2e_fixtures.rb
+++ b/backend_app/db/seeds/e2e_fixtures.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+# db/seeds/e2e_fixtures.rb
+#
+# Single source of truth for the E2E fixture *data* (deterministic accounts,
+# the enrolled course, its locations and live event). Requiring this file does
+# NO database work — it only defines frozen data. Two consumers read from it so
+# the seed and the Playwright specs can never drift:
+#
+#   * account_seeds.rb            — builds the fixtures in the DB from these.
+#   * rake generate:e2e_seed_data — emits `as_json` for the JS specs to import
+#                                    (e2e/seed-data.mjs), regenerated every run.
+#
+# Change a name or coordinate here and both the seeded DB and the specs that
+# reference it move together, automatically.
+module Tyto
+  module E2EFixtures
+    # System roles (admin/creator/member) are carried in the JWT credential.
+    # Emails use the reserved-for-tests `e2e.test` domain so they can never
+    # collide with a real Google account.
+    ACCOUNTS = {
+      admin:      { name: 'E2E Admin',      email: 'e2e-admin@e2e.test',      system_roles: %w[admin creator member] },
+      creator:    { name: 'E2E Creator',    email: 'e2e-creator@e2e.test',    system_roles: %w[creator member] },
+      owner:      { name: 'E2E Owner',      email: 'e2e-owner@e2e.test',      system_roles: %w[member] },
+      instructor: { name: 'E2E Instructor', email: 'e2e-instructor@e2e.test', system_roles: %w[member] },
+      staff:      { name: 'E2E Staff',      email: 'e2e-staff@e2e.test',      system_roles: %w[member] },
+      student:    { name: 'E2E Student',    email: 'e2e-student@e2e.test',    system_roles: %w[member] },
+      # Enrolled with TWO course roles so the SingleCourse "view as role" switcher
+      # has more than one option to switch between (task 8a).
+      multi:      { name: 'E2E Multi-role', email: 'e2e-multi@e2e.test',      system_roles: %w[member] }
+    }.freeze
+
+    # Per-course enrollment: account key => course role(s). admin + creator stay
+    # unenrolled so specs have a "not a member of this course" actor to assert on.
+    COURSE_ENROLLMENTS = {
+      owner: %w[owner],
+      instructor: %w[instructor],
+      staff: %w[staff],
+      student: %w[student],
+      multi: %w[instructor student]
+    }.freeze
+
+    COURSE_NAME = 'E2E Course'
+
+    # Geo-fenced location anchoring the live event's attendance check-in.
+    MAIN_HALL = { name: 'E2E Main Hall', latitude: 25.0330, longitude: 121.5654 }.freeze
+
+    # A second, event-free location the Locations spec can delete (task 14).
+    # Separate from Main Hall so deleting it never cascades the seeded event.
+    SPARE_ROOM = { name: 'E2E Spare Room', latitude: 25.0340, longitude: 121.5660 }.freeze
+
+    EVENT_NAME = 'E2E Live Session'
+
+    # Flattened, JS-idiomatic (camelCase) view emitted by the rake task and
+    # imported by e2e/seed-data.mjs. Only the values the specs reference.
+    def self.as_json
+      {
+        course: { name: COURSE_NAME },
+        event: { name: EVENT_NAME },
+        mainHall: MAIN_HALL,
+        spareRoom: SPARE_ROOM,
+        accounts: ACCOUNTS.transform_values { |spec| { name: spec[:name], email: spec[:email] } }
+      }
+    end
+  end
+end

--- a/backend_app/spec/infrastructure/database/setup_spec.rb
+++ b/backend_app/spec/infrastructure/database/setup_spec.rb
@@ -83,14 +83,27 @@ describe 'Database Setup from Scratch' do
       _(current_version).must_equal migration_count
 
       # Load seed file (this requires the app to be loaded)
-      # We need to temporarily set up the environment so models use our db
+      # We need to temporarily set up the environment so models use our db.
+      #
+      # Redirect EVERY model the seed writes to the setup DB — not just
+      # roles/accounts. The seed's E2E fixture block also creates courses,
+      # enrollments, locations and events; a partial redirect would split those
+      # across two databases and trip a cross-DB FOREIGN KEY violation.
+      seeded_models = {
+        Tyto::Role => :roles,
+        Tyto::Account => :accounts,
+        Tyto::Course => :courses,
+        Tyto::AccountCourse => :account_course_roles,
+        Tyto::Location => :locations,
+        Tyto::Event => :events
+      }
+
       original_db = Tyto::Api.instance_variable_get(:@db)
       original_admin_email = ENV['ADMIN_EMAIL']
       Tyto::Api.instance_variable_set(:@db, db)
 
       # Point Sequel models at the setup database (set_dataset takes a dataset, not db)
-      Tyto::Role.set_dataset(db[:roles])
-      Tyto::Account.set_dataset(db[:accounts]) if defined?(Tyto::Account)
+      seeded_models.each { |model, table| model.set_dataset(db[table]) }
 
       # Set ADMIN_EMAIL for seed file
       ENV['ADMIN_EMAIL'] = 'test-admin@example.com'
@@ -101,8 +114,7 @@ describe 'Database Setup from Scratch' do
       ensure
         # Restore original database connection and model datasets
         Tyto::Api.instance_variable_set(:@db, original_db)
-        Tyto::Role.set_dataset(original_db[:roles]) if original_db
-        Tyto::Account.set_dataset(original_db[:accounts]) if original_db && defined?(Tyto::Account)
+        seeded_models.each { |model, table| model.set_dataset(original_db[table]) } if original_db
         ENV['ADMIN_EMAIL'] = original_admin_email
       end
 

--- a/backend_app/spec/spec_helper.rb
+++ b/backend_app/spec/spec_helper.rb
@@ -20,7 +20,15 @@ require_relative 'support/test_helpers'
 
 # Database setup (run ONCE before all tests)
 DB = Tyto::Api.db
-DB.tables.each { |table| DB[table].delete }
+# Wipe every table before the suite. Disable FK enforcement for the wipe (on a
+# single held connection) so delete order doesn't matter — the seeded fixtures
+# (incl. the E2E course graph: course -> enrollments/locations/events) carry FK
+# relationships that an unordered table-by-table delete would otherwise violate.
+DB.synchronize do
+  DB.run('PRAGMA foreign_keys = OFF')
+  DB.tables.each { |table| DB[table].delete }
+  DB.run('PRAGMA foreign_keys = ON')
+end
 
 # Seed roles (same as production)
 %w[admin creator member owner instructor staff student].each do |role_name|

--- a/backend_app/spec/spec_helper.rb
+++ b/backend_app/spec/spec_helper.rb
@@ -26,8 +26,13 @@ DB = Tyto::Api.db
 # relationships that an unordered table-by-table delete would otherwise violate.
 DB.synchronize do
   DB.run('PRAGMA foreign_keys = OFF')
-  DB.tables.each { |table| DB[table].delete }
-  DB.run('PRAGMA foreign_keys = ON')
+  begin
+    DB.tables.each { |table| DB[table].delete }
+  ensure
+    # Always restore enforcement, even if a delete raises — otherwise FK checks
+    # would stay OFF for the rest of the suite and mask integrity issues.
+    DB.run('PRAGMA foreign_keys = ON')
+  end
 end
 
 # Seed roles (same as production)

--- a/doc/testing.md
+++ b/doc/testing.md
@@ -1,0 +1,153 @@
+# Testing Guide
+
+TYTO has three test layers, each with its own runner and scope:
+
+| Layer | Tool | Scope | Files | Command |
+| --- | --- | --- | --- | --- |
+| **Backend** | Minitest (spec style) | API routes, services, policies, domain entities | `backend_app/spec/**/*_spec.rb` | `bundle exec rake spec:backend` |
+| **Frontend** | Vitest + `@vue/test-utils` (jsdom) | Vue components in isolation | `frontend_app/**/*.{test,spec}.js` | `bundle exec rake spec:frontend` |
+| **End-to-end** | Playwright (Chromium) | Real browser driving the live SPA + Roda API | `e2e/**/*.spec.mjs` | `bundle exec rake spec:e2e` |
+
+```shell
+bundle exec rake spec        # Backend + frontend (the default task). Does NOT run e2e.
+bundle exec rake spec:e2e    # End-to-end, opt-in and self-contained (see below).
+```
+
+E2E is intentionally **not** part of `rake spec`: it is slower, needs a built frontend
+and a booted server, and resets its own database. Run it explicitly.
+
+---
+
+## Backend (Minitest)
+
+Spec-style Minitest (`describe`/`it`) — **not** RSpec. Specs live alongside the app under
+`backend_app/spec/` and exercise routes, services, policies, and domain logic.
+
+```shell
+RACK_ENV=test bundle exec rake db:setup   # First time / after schema or seed changes
+bundle exec rake spec:backend
+```
+
+The suite reports **one intentional skip** (`courses_spec.rb` — testing a missing `owner`
+role would require deleting seed data the rest of the suite depends on). Expected; not a
+regression.
+
+> **TDD protocol** for backend work: red → green → refactor, one test at a time. Write the
+> failing test first, run it to confirm the failure, then implement. See `CLAUDE.md`.
+
+---
+
+## Frontend (Vitest)
+
+Component-level tests in jsdom via `vitest` + `@vue/test-utils`. Config lives in
+`vitest.config.mjs` (mirrors the webpack `@` → `frontend_app` alias). Element Plus is
+auto-imported by webpack in the real app but not under Vitest, so specs stub `el-*`
+components explicitly.
+
+```shell
+bundle exec rake spec:frontend   # === npm test === vitest run
+npm run test:watch               # Watch mode while developing
+```
+
+No database or server is required.
+
+---
+
+## End-to-end (Playwright)
+
+Browser-based tests that drive the **real** Vue SPA served by the Roda backend on `:9292`,
+against a dedicated `RACK_ENV=test` database. They cover role-gated behavior end to end —
+system roles (admin, creator, member) and per-course enrollment roles (owner, instructor,
+staff, student).
+
+### One command
+
+```shell
+bundle exec rake spec:e2e
+```
+
+This task is self-contained. It:
+
+1. **Resets the test DB** as three separate processes — `db:drop`, then `db:migrate`, then
+   `db:seed`. (A single-process `db:reset` is broken for SQLite; see *Gotchas* below.)
+2. **Builds the frontend** into `dist/` via `npm run prod` (the backend serves these assets).
+3. **Runs Playwright** (`npx playwright test`), which boots the backend itself (see the
+   `webServer` block in `playwright.config.mjs`) and runs all specs in `e2e/`.
+
+### First-time setup
+
+```shell
+npm install                              # Installs @playwright/test
+npx playwright install --with-deps chromium   # One-time browser download
+```
+
+### Running a subset / debugging
+
+```shell
+npm run e2e                  # playwright test  (server must already be running, or it boots one)
+npm run e2e:headed           # Watch it drive a visible browser
+npm run e2e:ui               # Playwright's interactive UI mode
+npx playwright test e2e/auth.spec.mjs        # A single file
+npx playwright show-report                   # Open the HTML report after a run
+```
+
+> When running Playwright directly (not via `rake spec:e2e`), you are responsible for the
+> prerequisites that the rake task normally handles: a seeded test DB and a built `dist/`.
+> The simplest path is just `bundle exec rake spec:e2e`.
+
+### How auth works (cookie injection, no Google)
+
+Production login goes through Google OAuth, but the e2e suite bypasses it — Google is flaky
+and unusable in CI. Instead:
+
+- The seed creates deterministic accounts on the reserved `@e2e.test` domain
+  (`e2e-owner@e2e.test`, `e2e-student@e2e.test`, …) and one `E2E Course` with the four
+  enrollment roles, a geo-fenced `E2E Main Hall` location, and a live event.
+  See `backend_app/db/seeds/account_seeds.rb`.
+- Playwright **global setup** (`e2e/global-setup.mjs`) runs `rake generate:e2e_credentials`
+  once, minting a real encrypted credential for each `@e2e.test` account, and caches them to
+  `e2e/.auth/credentials.json` (gitignored).
+- The `loginAs(role)` fixture (`e2e/fixtures.mjs`) reads that cache and sets the five session
+  cookies on the browser context, so the SPA boots already authenticated as that role —
+  with real, authorized API calls.
+
+To mint a credential for a single account manually:
+
+```shell
+RACK_ENV=test bundle exec rake "generate:test_credential[e2e-owner@e2e.test]"
+```
+
+### Config & environment
+
+- `playwright.config.mjs` — `testDir: ./e2e`, `testMatch: **/*.spec.mjs` (so it never
+  collides with Vitest's `.spec.js`), Chromium only, traces on first retry, screenshots on
+  failure.
+- `E2E_BASE_URL` — override the target URL (default `http://localhost:9292`).
+
+### CI
+
+The `e2e-tests` job in `.github/workflows/ci.yml` installs Ruby + Node, writes a
+`secrets.yml` (including `LOCAL_STORAGE_*`), installs the Chromium browser, and runs
+`bundle exec rake spec:e2e` headless (`workers: 1`, `retries: 2`), uploading the
+`playwright-report/` artifact.
+
+### Gotchas
+
+- **`db:reset` is broken for SQLite.** Dropping unlinks the DB file while the boot-time
+  connection stays open and keeps writing to the stale inode, so the next `migrate` sees
+  "table already exists". `spec:e2e` works around it by running `db:drop`, `db:migrate`, and
+  `db:seed` as three separate processes (each opens a fresh connection on the fresh file).
+  Don't collapse those three lines back into `db:reset`.
+- **Some specs mutate shared state** (geo check-in records attendance, locations delete the
+  spare room, people/assignments/courses create rows) and assume a fresh DB. `rake spec:e2e`
+  resets every run, so this only bites if you re-run specs against a long-lived dev server.
+- **`LOCAL_STORAGE_*` secrets** must be present in the `test` section of
+  `backend_app/config/secrets.yml` (assignment submission needs them at boot). CI generates
+  them; `secrets_example.yml` lists them for local setup.
+
+### Scope & limitations
+
+- Chromium only (WebKit/Firefox deferred).
+- Location create/update is not covered — coordinate picking happens inside a Google Maps
+  InfoWindow that needs a live API key (not headless-testable). List + delete are covered.
+- The Google OAuth login UI is not exercised (bypassed by design via cookie injection).

--- a/e2e/assignments.spec.mjs
+++ b/e2e/assignments.spec.mjs
@@ -1,60 +1,19 @@
 import { test, expect } from './fixtures.mjs';
-import { openCourseTab, openE2eCourse } from './helpers.mjs';
 
 // Plan tasks 12a (manager assignment lifecycle: create -> publish -> unpublish)
 // and 12b (students see only published assignments, with no management controls).
 
-// Within an assignment card, the actions are [Edit, Publish|Unpublish, Delete];
-// index 1 is the publish/unpublish toggle regardless of title attributes.
-function statusToggle(card) {
-  return card.locator('.assignment-actions .el-icon').nth(1);
-}
-
-async function createAssignment(page, title, { urlRequirement } = {}) {
-  await page.locator('.assignment-item', { hasText: 'Create Assignment' }).click();
-  const dlg = page.getByRole('dialog', { name: 'Create Assignment' });
-  await expect(dlg).toBeVisible();
-  await dlg.getByPlaceholder('Assignment title').fill(title);
-
-  if (urlRequirement) {
-    // The dialog seeds one (file, empty-description) requirement row. Switch it
-    // to a URL requirement so a student can submit without a file upload.
-    const row = dlg.locator('.requirement-row').first();
-    await row.locator('.el-select').click();
-    await page.locator('.el-select-dropdown__item', { hasText: 'URL' }).click();
-    await row.getByPlaceholder(/Description/).fill(urlRequirement);
-  }
-
-  await dlg.getByRole('button', { name: 'Create' }).click();
-  await expect(dlg).toBeHidden();
-}
-
-async function publishCard(page, card) {
-  await statusToggle(card).click();
-  await page.getByRole('button', { name: 'Publish' }).click();
-  await expect(card.locator('.el-tag')).toHaveText('published');
-}
-
 test.describe('Assignments — manager lifecycle (task 12a)', () => {
-  test('owner creates a draft, publishes it, then unpublishes it', async ({ page, loginAs }) => {
+  test('owner creates a draft, publishes it, then unpublishes it', async ({ loginAs, assignmentsPage }) => {
     await loginAs('owner');
-    await openCourseTab(page, 'Assignments');
+    await assignmentsPage.open();
 
     const title = `PW Assignment ${Date.now()}`;
-    await createAssignment(page, title);
+    await assignmentsPage.create(title);
+    await expect(assignmentsPage.status(title)).toHaveText('draft');
 
-    const card = page.locator('.assignment-item', { hasText: title });
-    await expect(card.locator('.el-tag')).toHaveText('draft');
-
-    // Publish (confirm dialog -> "Publish").
-    await statusToggle(card).click();
-    await page.getByRole('button', { name: 'Publish' }).click();
-    await expect(card.locator('.el-tag')).toHaveText('published');
-
-    // Unpublish (confirm dialog -> "Unpublish").
-    await statusToggle(card).click();
-    await page.getByRole('button', { name: 'Unpublish' }).click();
-    await expect(card.locator('.el-tag')).toHaveText('draft');
+    await assignmentsPage.publish(title);   // confirm dialog -> "Publish", asserts published
+    await assignmentsPage.unpublish(title); // confirm dialog -> "Unpublish", asserts draft
   });
 });
 
@@ -63,52 +22,47 @@ test.describe.serial('Assignments — student visibility (task 12b)', () => {
   const publishedTitle = `PW Published ${stamp}`;
   const draftTitle = `PW Draft ${stamp}`;
 
-  test('owner creates one published and one draft assignment', async ({ page, loginAs }) => {
+  test('owner creates one published and one draft assignment', async ({ loginAs, assignmentsPage }) => {
     await loginAs('owner');
-    await openCourseTab(page, 'Assignments');
+    await assignmentsPage.open();
 
-    await createAssignment(page, publishedTitle);
-    await publishCard(page, page.locator('.assignment-item', { hasText: publishedTitle }));
+    await assignmentsPage.create(publishedTitle);
+    await assignmentsPage.publish(publishedTitle);
 
-    await createAssignment(page, draftTitle);
-    await expect(page.locator('.assignment-item', { hasText: draftTitle }).locator('.el-tag')).toHaveText('draft');
+    await assignmentsPage.create(draftTitle);
+    await expect(assignmentsPage.status(draftTitle)).toHaveText('draft');
   });
 
-  test('student sees the published assignment but not the draft, and no controls', async ({ page, loginAs }) => {
+  test('student sees the published assignment but not the draft, and no controls', async ({ loginAs, assignmentsPage }) => {
     await loginAs('student');
-    await openE2eCourse(page); // redirected to the assignments (read-only) view
+    await assignmentsPage.openAsStudent(); // redirected to the read-only assignments view
 
-    await expect(page.locator('.assignment-item', { hasText: publishedTitle })).toBeVisible();
-    await expect(page.locator('.assignment-item', { hasText: draftTitle })).toHaveCount(0);
+    await expect(assignmentsPage.card(publishedTitle)).toBeVisible();
+    await expect(assignmentsPage.card(draftTitle)).toHaveCount(0);
     // Read-only: no Create card and no status tags / action icons.
-    await expect(page.locator('.assignment-item', { hasText: 'Create Assignment' })).toHaveCount(0);
-    await expect(page.locator('.assignment-item .assignment-actions')).toHaveCount(0);
+    await expect(assignmentsPage.createCard).toHaveCount(0);
+    await expect(assignmentsPage.actionGroups).toHaveCount(0);
   });
 });
 
 test.describe.serial('Assignments — student submission (task 12b)', () => {
   const title = `PW Submittable ${Date.now()}`;
 
-  test('owner creates and publishes an assignment with a URL requirement', async ({ page, loginAs }) => {
+  test('owner creates and publishes an assignment with a URL requirement', async ({ loginAs, assignmentsPage }) => {
     await loginAs('owner');
-    await openCourseTab(page, 'Assignments');
+    await assignmentsPage.open();
 
-    await createAssignment(page, title, { urlRequirement: 'Project repository URL' });
-    await publishCard(page, page.locator('.assignment-item', { hasText: title }));
+    await assignmentsPage.create(title, { urlRequirement: 'Project repository URL' });
+    await assignmentsPage.publish(title);
   });
 
-  test('student submits a URL to the published assignment', async ({ page, loginAs }) => {
+  test('student submits a URL to the published assignment', async ({ loginAs, assignmentsPage }) => {
     await loginAs('student');
-    await openE2eCourse(page);
+    await assignmentsPage.openAsStudent();
 
-    await page.locator('.assignment-item', { hasText: title }).click();
-    const dlg = page.getByRole('dialog', { name: title });
-    await expect(dlg).toBeVisible();
+    const dlg = await assignmentsPage.submitUrl(title, 'https://github.com/example/project');
 
-    await dlg.getByPlaceholder('Enter URL').fill('https://github.com/example/project');
-    await dlg.getByRole('button', { name: 'Submit', exact: true }).click();
-
-    await expect(page.getByText('Submission saved')).toBeVisible();
+    await expect(dlg.page().getByText('Submission saved')).toBeVisible();
     await expect(dlg.getByText('Your Submission')).toBeVisible();
   });
 });

--- a/e2e/assignments.spec.mjs
+++ b/e2e/assignments.spec.mjs
@@ -1,0 +1,114 @@
+import { test, expect } from './fixtures.mjs';
+import { openCourseTab, openE2eCourse } from './helpers.mjs';
+
+// Plan tasks 12a (manager assignment lifecycle: create -> publish -> unpublish)
+// and 12b (students see only published assignments, with no management controls).
+
+// Within an assignment card, the actions are [Edit, Publish|Unpublish, Delete];
+// index 1 is the publish/unpublish toggle regardless of title attributes.
+function statusToggle(card) {
+  return card.locator('.assignment-actions .el-icon').nth(1);
+}
+
+async function createAssignment(page, title, { urlRequirement } = {}) {
+  await page.locator('.assignment-item', { hasText: 'Create Assignment' }).click();
+  const dlg = page.getByRole('dialog', { name: 'Create Assignment' });
+  await expect(dlg).toBeVisible();
+  await dlg.getByPlaceholder('Assignment title').fill(title);
+
+  if (urlRequirement) {
+    // The dialog seeds one (file, empty-description) requirement row. Switch it
+    // to a URL requirement so a student can submit without a file upload.
+    const row = dlg.locator('.requirement-row').first();
+    await row.locator('.el-select').click();
+    await page.locator('.el-select-dropdown__item', { hasText: 'URL' }).click();
+    await row.getByPlaceholder(/Description/).fill(urlRequirement);
+  }
+
+  await dlg.getByRole('button', { name: 'Create' }).click();
+  await expect(dlg).toBeHidden();
+}
+
+async function publishCard(page, card) {
+  await statusToggle(card).click();
+  await page.getByRole('button', { name: 'Publish' }).click();
+  await expect(card.locator('.el-tag')).toHaveText('published');
+}
+
+test.describe('Assignments — manager lifecycle (task 12a)', () => {
+  test('owner creates a draft, publishes it, then unpublishes it', async ({ page, loginAs }) => {
+    await loginAs('owner');
+    await openCourseTab(page, 'Assignments');
+
+    const title = `PW Assignment ${Date.now()}`;
+    await createAssignment(page, title);
+
+    const card = page.locator('.assignment-item', { hasText: title });
+    await expect(card.locator('.el-tag')).toHaveText('draft');
+
+    // Publish (confirm dialog -> "Publish").
+    await statusToggle(card).click();
+    await page.getByRole('button', { name: 'Publish' }).click();
+    await expect(card.locator('.el-tag')).toHaveText('published');
+
+    // Unpublish (confirm dialog -> "Unpublish").
+    await statusToggle(card).click();
+    await page.getByRole('button', { name: 'Unpublish' }).click();
+    await expect(card.locator('.el-tag')).toHaveText('draft');
+  });
+});
+
+test.describe.serial('Assignments — student visibility (task 12b)', () => {
+  const stamp = Date.now();
+  const publishedTitle = `PW Published ${stamp}`;
+  const draftTitle = `PW Draft ${stamp}`;
+
+  test('owner creates one published and one draft assignment', async ({ page, loginAs }) => {
+    await loginAs('owner');
+    await openCourseTab(page, 'Assignments');
+
+    await createAssignment(page, publishedTitle);
+    await publishCard(page, page.locator('.assignment-item', { hasText: publishedTitle }));
+
+    await createAssignment(page, draftTitle);
+    await expect(page.locator('.assignment-item', { hasText: draftTitle }).locator('.el-tag')).toHaveText('draft');
+  });
+
+  test('student sees the published assignment but not the draft, and no controls', async ({ page, loginAs }) => {
+    await loginAs('student');
+    await openE2eCourse(page); // redirected to the assignments (read-only) view
+
+    await expect(page.locator('.assignment-item', { hasText: publishedTitle })).toBeVisible();
+    await expect(page.locator('.assignment-item', { hasText: draftTitle })).toHaveCount(0);
+    // Read-only: no Create card and no status tags / action icons.
+    await expect(page.locator('.assignment-item', { hasText: 'Create Assignment' })).toHaveCount(0);
+    await expect(page.locator('.assignment-item .assignment-actions')).toHaveCount(0);
+  });
+});
+
+test.describe.serial('Assignments — student submission (task 12b)', () => {
+  const title = `PW Submittable ${Date.now()}`;
+
+  test('owner creates and publishes an assignment with a URL requirement', async ({ page, loginAs }) => {
+    await loginAs('owner');
+    await openCourseTab(page, 'Assignments');
+
+    await createAssignment(page, title, { urlRequirement: 'Project repository URL' });
+    await publishCard(page, page.locator('.assignment-item', { hasText: title }));
+  });
+
+  test('student submits a URL to the published assignment', async ({ page, loginAs }) => {
+    await loginAs('student');
+    await openE2eCourse(page);
+
+    await page.locator('.assignment-item', { hasText: title }).click();
+    const dlg = page.getByRole('dialog', { name: title });
+    await expect(dlg).toBeVisible();
+
+    await dlg.getByPlaceholder('Enter URL').fill('https://github.com/example/project');
+    await dlg.getByRole('button', { name: 'Submit', exact: true }).click();
+
+    await expect(page.getByText('Submission saved')).toBeVisible();
+    await expect(dlg.getByText('Your Submission')).toBeVisible();
+  });
+});

--- a/e2e/attendance-checkin.spec.mjs
+++ b/e2e/attendance-checkin.spec.mjs
@@ -1,4 +1,5 @@
 import { test, expect } from './fixtures.mjs';
+import { SEED } from './seed-data.mjs';
 
 // Plan task 11 — student geo-fenced attendance check-in.
 //
@@ -12,37 +13,36 @@ import { test, expect } from './fixtures.mjs';
 // success attempt records last. Assumes a freshly-seeded DB (rake spec:e2e),
 // since a recorded attendance hides the button on re-run.
 
-const FENCE = { latitude: 25.0330, longitude: 121.5654 }; // E2E Main Hall
+// The geo-fence is the seeded Main Hall's own coordinates (the event is held
+// there), sourced from the seed so the fence and the location never drift.
+const FENCE = { latitude: SEED.mainHall.latitude, longitude: SEED.mainHall.longitude };
 const FAR_AWAY = { latitude: 24.0, longitude: 121.0 }; // ~100+ km away
+const LIVE_SESSION = SEED.event.name;
 
 test.use({ permissions: ['geolocation'], geolocation: FENCE });
 
 test.describe.serial('Student attendance check-in (task 11)', () => {
-  function liveSessionCard(page) {
-    return page.locator('.course-item', { hasText: 'E2E Live Session' });
-  }
-
-  test('rejects check-in from outside the geo-fence', async ({ page, context, loginAs }) => {
+  test('rejects check-in from outside the geo-fence', async ({ page, context, loginAs, coursesPage }) => {
     await context.setGeolocation(FAR_AWAY);
     await loginAs('student');
-    await page.goto('/');
+    await coursesPage.goto();
 
-    await liveSessionCard(page).getByRole('button', { name: 'Mark Attendance' }).click();
+    await coursesPage.markAttendance(LIVE_SESSION);
 
     // recordAttendance surfaces the backend 403 detail in an alert.
     await expect(page.getByText(/outside the allowed geo-fence range/i)).toBeVisible();
   });
 
-  test('accepts check-in from inside the geo-fence', async ({ page, context, loginAs }) => {
+  test('accepts check-in from inside the geo-fence', async ({ page, context, loginAs, coursesPage }) => {
     await context.setGeolocation(FENCE);
     await loginAs('student');
-    await page.goto('/');
+    await coursesPage.goto();
 
-    await liveSessionCard(page).getByRole('button', { name: 'Mark Attendance' }).click();
+    await coursesPage.markAttendance(LIVE_SESSION);
 
     await expect(page.getByText('Attendance recorded successfully')).toBeVisible();
     // Dismiss the success alert; the card flips to the recorded state.
     await page.getByRole('button', { name: 'OK' }).click();
-    await expect(liveSessionCard(page).getByRole('button', { name: 'Attendance Recorded' })).toBeVisible();
+    await expect(coursesPage.eventCard(LIVE_SESSION).getByRole('button', { name: 'Attendance Recorded' })).toBeVisible();
   });
 });

--- a/e2e/attendance-checkin.spec.mjs
+++ b/e2e/attendance-checkin.spec.mjs
@@ -1,0 +1,48 @@
+import { test, expect } from './fixtures.mjs';
+
+// Plan task 11 — student geo-fenced attendance check-in.
+//
+// The home page (AllCourse) lists active events with a "Mark Attendance"
+// button; recordAttendance() reads navigator.geolocation and POSTs lat/long.
+// The backend enforces a 55m geo-fence (Haversine) and the event time window.
+// We mock the browser position with Playwright's geolocation context option.
+//
+// Serial + rejection-first: the rejection attempt records nothing, so the
+// "Mark Attendance" button is still present for the success attempt; the
+// success attempt records last. Assumes a freshly-seeded DB (rake spec:e2e),
+// since a recorded attendance hides the button on re-run.
+
+const FENCE = { latitude: 25.0330, longitude: 121.5654 }; // E2E Main Hall
+const FAR_AWAY = { latitude: 24.0, longitude: 121.0 }; // ~100+ km away
+
+test.use({ permissions: ['geolocation'], geolocation: FENCE });
+
+test.describe.serial('Student attendance check-in (task 11)', () => {
+  function liveSessionCard(page) {
+    return page.locator('.course-item', { hasText: 'E2E Live Session' });
+  }
+
+  test('rejects check-in from outside the geo-fence', async ({ page, context, loginAs }) => {
+    await context.setGeolocation(FAR_AWAY);
+    await loginAs('student');
+    await page.goto('/');
+
+    await liveSessionCard(page).getByRole('button', { name: 'Mark Attendance' }).click();
+
+    // recordAttendance surfaces the backend 403 detail in an alert.
+    await expect(page.getByText(/outside the allowed geo-fence range/i)).toBeVisible();
+  });
+
+  test('accepts check-in from inside the geo-fence', async ({ page, context, loginAs }) => {
+    await context.setGeolocation(FENCE);
+    await loginAs('student');
+    await page.goto('/');
+
+    await liveSessionCard(page).getByRole('button', { name: 'Mark Attendance' }).click();
+
+    await expect(page.getByText('Attendance recorded successfully')).toBeVisible();
+    // Dismiss the success alert; the card flips to the recorded state.
+    await page.getByRole('button', { name: 'OK' }).click();
+    await expect(liveSessionCard(page).getByRole('button', { name: 'Attendance Recorded' })).toBeVisible();
+  });
+});

--- a/e2e/attendance-events.spec.mjs
+++ b/e2e/attendance-events.spec.mjs
@@ -1,60 +1,41 @@
 import { test, expect } from './fixtures.mjs';
-import { openCourseTab, openE2eCourse } from './helpers.mjs';
+import { SEED } from './seed-data.mjs';
 
 // Plan tasks 10a (manager create/delete attendance events) and 10b (students
 // never reach the management view — covered structurally by 8b, re-asserted at
 // the controls level here).
 
 test.describe('Attendance events — manager (task 10a)', () => {
-  test('owner sees management controls, creates an event, then deletes it', async ({ page, loginAs }) => {
+  test('owner sees management controls, creates an event, then deletes it', async ({ loginAs, attendanceEventsPage }) => {
     await loginAs('owner');
-    await openCourseTab(page, 'Attendance Events');
+    await attendanceEventsPage.open();
 
     // Manager-only controls are present.
-    await expect(page.getByRole('button', { name: 'Download Record' })).toBeVisible();
-    const createCard = page.locator('.event-item', { hasText: 'Create Event' });
-    await expect(createCard).toBeVisible();
+    await expect(attendanceEventsPage.downloadButton).toBeVisible();
+    await expect(attendanceEventsPage.createCard).toBeVisible();
 
     const eventName = `PW Event ${Date.now()}`;
+    await attendanceEventsPage.createEvent(eventName, {
+      location: SEED.mainHall.name,
+      start: '2026-07-01 09:00:00',
+      end: '2026-07-01 11:00:00',
+    });
 
-    await createCard.click();
-    const dlg = page.getByRole('dialog', { name: 'Create Attendance Event' });
-    await expect(dlg).toBeVisible();
+    await expect(attendanceEventsPage.card(eventName)).toBeVisible();
 
-    await dlg.getByPlaceholder('e.g. Week 08 Lecture').fill(eventName);
-
-    // Location select -> E2E Main Hall
-    await dlg.locator('.el-form-item', { hasText: 'Location' }).locator('.el-select').click();
-    await page.locator('.el-select-dropdown__item', { hasText: 'E2E Main Hall' }).click();
-
-    // Datetime pickers accept typed input in "YYYY-MM-DD HH:mm:ss"; Enter commits.
-    const startInput = dlg.getByPlaceholder('Select start time');
-    await startInput.fill('2026-07-01 09:00:00');
-    await startInput.press('Enter');
-    const endInput = dlg.getByPlaceholder('Select end time');
-    await endInput.fill('2026-07-01 11:00:00');
-    await endInput.press('Enter');
-
-    await dlg.getByRole('button', { name: 'Create event' }).click();
-    await expect(dlg).toBeHidden();
-
-    const card = page.locator('.event-item', { hasText: eventName });
-    await expect(card).toBeVisible();
-
-    // Delete it (the trash icon is the last el-icon in the card).
-    await card.locator('.el-icon').last().click();
-    await expect(page.locator('.event-item', { hasText: eventName })).toHaveCount(0);
+    await attendanceEventsPage.deleteEvent(eventName);
+    await expect(attendanceEventsPage.card(eventName)).toHaveCount(0);
   });
 });
 
 test.describe('Attendance events — student (task 10b)', () => {
-  test('student cannot reach the attendance view or its controls', async ({ page, loginAs }) => {
+  test('student cannot reach the attendance view or its controls', async ({ page, loginAs, singleCoursePage, attendanceEventsPage }) => {
     await loginAs('student');
-    await openE2eCourse(page);
+    await singleCoursePage.open();
 
     // redirectIfNotManager sends students to the assignments view.
-    await expect(page).toHaveURL(/\/course\/\d+\/assignments/);
-    await expect(page.getByRole('button', { name: 'Download Record' })).toHaveCount(0);
-    await expect(page.locator('.event-item', { hasText: 'Create Event' })).toHaveCount(0);
+    await expect(page).toHaveURL(singleCoursePage.assignmentsUrl);
+    await expect(attendanceEventsPage.downloadButton).toHaveCount(0);
+    await expect(attendanceEventsPage.createCard).toHaveCount(0);
   });
 });

--- a/e2e/attendance-events.spec.mjs
+++ b/e2e/attendance-events.spec.mjs
@@ -1,0 +1,60 @@
+import { test, expect } from './fixtures.mjs';
+import { openCourseTab, openE2eCourse } from './helpers.mjs';
+
+// Plan tasks 10a (manager create/delete attendance events) and 10b (students
+// never reach the management view — covered structurally by 8b, re-asserted at
+// the controls level here).
+
+test.describe('Attendance events — manager (task 10a)', () => {
+  test('owner sees management controls, creates an event, then deletes it', async ({ page, loginAs }) => {
+    await loginAs('owner');
+    await openCourseTab(page, 'Attendance Events');
+
+    // Manager-only controls are present.
+    await expect(page.getByRole('button', { name: 'Download Record' })).toBeVisible();
+    const createCard = page.locator('.event-item', { hasText: 'Create Event' });
+    await expect(createCard).toBeVisible();
+
+    const eventName = `PW Event ${Date.now()}`;
+
+    await createCard.click();
+    const dlg = page.getByRole('dialog', { name: 'Create Attendance Event' });
+    await expect(dlg).toBeVisible();
+
+    await dlg.getByPlaceholder('e.g. Week 08 Lecture').fill(eventName);
+
+    // Location select -> E2E Main Hall
+    await dlg.locator('.el-form-item', { hasText: 'Location' }).locator('.el-select').click();
+    await page.locator('.el-select-dropdown__item', { hasText: 'E2E Main Hall' }).click();
+
+    // Datetime pickers accept typed input in "YYYY-MM-DD HH:mm:ss"; Enter commits.
+    const startInput = dlg.getByPlaceholder('Select start time');
+    await startInput.fill('2026-07-01 09:00:00');
+    await startInput.press('Enter');
+    const endInput = dlg.getByPlaceholder('Select end time');
+    await endInput.fill('2026-07-01 11:00:00');
+    await endInput.press('Enter');
+
+    await dlg.getByRole('button', { name: 'Create event' }).click();
+    await expect(dlg).toBeHidden();
+
+    const card = page.locator('.event-item', { hasText: eventName });
+    await expect(card).toBeVisible();
+
+    // Delete it (the trash icon is the last el-icon in the card).
+    await card.locator('.el-icon').last().click();
+    await expect(page.locator('.event-item', { hasText: eventName })).toHaveCount(0);
+  });
+});
+
+test.describe('Attendance events — student (task 10b)', () => {
+  test('student cannot reach the attendance view or its controls', async ({ page, loginAs }) => {
+    await loginAs('student');
+    await openE2eCourse(page);
+
+    // redirectIfNotManager sends students to the assignments view.
+    await expect(page).toHaveURL(/\/course\/\d+\/assignments/);
+    await expect(page.getByRole('button', { name: 'Download Record' })).toHaveCount(0);
+    await expect(page.locator('.event-item', { hasText: 'Create Event' })).toHaveCount(0);
+  });
+});

--- a/e2e/auth.spec.mjs
+++ b/e2e/auth.spec.mjs
@@ -1,0 +1,43 @@
+import { test, expect, ROLES } from './fixtures.mjs';
+
+// Plan tasks 6a — auth / session via cookie injection. These also smoke-test
+// the whole harness: seed -> mint -> cookie injection -> SPA boots authed.
+
+test.describe('Authentication / session', () => {
+  test('unauthenticated visit redirects to /login', async ({ page }) => {
+    await page.goto('/course');
+    await expect(page).toHaveURL(/\/login/);
+  });
+
+  for (const role of ROLES) {
+    test(`cookie-injection login as ${role} lands authenticated (not /login)`, async ({ page, loginAs }) => {
+      const account = await loginAs(role);
+      await page.goto('/');
+
+      // App.vue redirects to /login when session.getAccount() is falsy; staying
+      // off /login proves the injected session was accepted.
+      await expect(page).not.toHaveURL(/\/login/);
+
+      // The SPA recognizes the account: the credential cookie round-tripped.
+      const credential = await page.evaluate(() =>
+        document.cookie.split('; ').find((c) => c.startsWith('account_credential='))?.slice('account_credential='.length),
+      );
+      expect(credential).toBe(account.credential);
+    });
+  }
+
+  test('logout clears the session and forces re-login', async ({ page, loginAs }) => {
+    await loginAs('owner');
+    await page.goto('/');
+    await expect(page).not.toHaveURL(/\/login/);
+
+    // The avatar popover holds the Logout control (renders because E2E accounts
+    // have an avatar). Hover to reveal it, then click.
+    await page.locator('.avatar-btn').first().hover();
+    await page.getByText('Logout', { exact: true }).click();
+
+    await expect(page).toHaveURL(/\/login/);
+    const hasCredential = await page.evaluate(() => document.cookie.includes('account_credential='));
+    expect(hasCredential).toBe(false);
+  });
+});

--- a/e2e/auth.spec.mjs
+++ b/e2e/auth.spec.mjs
@@ -4,19 +4,19 @@ import { test, expect, ROLES } from './fixtures.mjs';
 // the whole harness: seed -> mint -> cookie injection -> SPA boots authed.
 
 test.describe('Authentication / session', () => {
-  test('unauthenticated visit redirects to /login', async ({ page }) => {
-    await page.goto('/course');
-    await expect(page).toHaveURL(/\/login/);
+  test('unauthenticated visit redirects to /login', async ({ page, coursesPage, loginPage }) => {
+    await page.goto(coursesPage.path);
+    await expect(page).toHaveURL(loginPage.url);
   });
 
   for (const role of ROLES) {
-    test(`cookie-injection login as ${role} lands authenticated (not /login)`, async ({ page, loginAs }) => {
+    test(`cookie-injection login as ${role} lands authenticated (not /login)`, async ({ page, loginAs, coursesPage, loginPage }) => {
       const account = await loginAs(role);
-      await page.goto('/');
+      await coursesPage.goto();
 
       // App.vue redirects to /login when session.getAccount() is falsy; staying
       // off /login proves the injected session was accepted.
-      await expect(page).not.toHaveURL(/\/login/);
+      await expect(page).not.toHaveURL(loginPage.url);
 
       // The SPA recognizes the account: the credential cookie round-tripped.
       const credential = await page.evaluate(() =>
@@ -26,17 +26,14 @@ test.describe('Authentication / session', () => {
     });
   }
 
-  test('logout clears the session and forces re-login', async ({ page, loginAs }) => {
+  test('logout clears the session and forces re-login', async ({ page, loginAs, appShell, coursesPage, loginPage }) => {
     await loginAs('owner');
-    await page.goto('/');
-    await expect(page).not.toHaveURL(/\/login/);
+    await coursesPage.goto();
+    await expect(page).not.toHaveURL(loginPage.url);
 
-    // The avatar popover holds the Logout control (renders because E2E accounts
-    // have an avatar). Hover to reveal it, then click.
-    await page.locator('.avatar-btn').first().hover();
-    await page.getByText('Logout', { exact: true }).click();
+    await appShell.logout();
 
-    await expect(page).toHaveURL(/\/login/);
+    await expect(page).toHaveURL(loginPage.url);
     const hasCredential = await page.evaluate(() => document.cookie.includes('account_credential='));
     expect(hasCredential).toBe(false);
   });

--- a/e2e/components/roles-dialog.mjs
+++ b/e2e/components/roles-dialog.mjs
@@ -1,0 +1,50 @@
+import { expect } from '@playwright/test';
+import { Select } from './select.mjs';
+
+// The "Edit Account" dialog. Two *separate* screens render their own
+// near-identical copy of it (app-level duplication, not a shared component):
+//  - ManagePeopleCard.vue   — edits a course enrollment's roles (enroll_identity)
+//  - ManageAccount.vue      — edits an account's system roles
+// Both produce the same accessible shape — title="Edit Account", a multi-select
+// "Roles" field, and a Confirm footer button — so one object drives both. Open
+// it from the target row's Edit button first.
+export class RolesDialog {
+  constructor(page) {
+    this.page = page;
+    this.dialog = page.getByRole('dialog', { name: 'Edit Account' });
+  }
+
+  async expectOpen() {
+    await expect(this.dialog).toBeVisible();
+    return this;
+  }
+
+  // Add a role to the multi-select. EP keeps the overlay open after a pick, so
+  // Select.add() dismisses it so the Confirm button below is clickable.
+  async addRole(role) {
+    await Select.inForm(this.dialog, 'Roles').add(role);
+    return this;
+  }
+
+  // Click Confirm. Intentionally does NOT wait for the dialog to disappear:
+  // ManageAccount's account list doesn't carry roles, so its row reflects the
+  // change only transiently (via the by-reference row mutation) before its
+  // refetch clears it — a toBeHidden() wait here would lose that race. Callers
+  // assert the resulting row state directly; for durable updates (People) that
+  // assertion auto-retries past the dialog close anyway.
+  async confirm() {
+    await this.dialog.getByRole('button', { name: 'Confirm' }).click();
+  }
+}
+
+// Drive the "Edit Account" dialog from a table row found by email: click that
+// row's Edit, add a role, Confirm. Shared by PeoplePage and ManageAccountPage,
+// whose tables and dialogs are identical at this level. Callers assert the
+// resulting row state themselves (durable for People, transient for ManageAccount
+// — see confirm()).
+export async function editRolesByEmail(page, email, role) {
+  await page.getByRole('row', { name: new RegExp(email) }).getByRole('button', { name: 'Edit' }).click();
+  const dialog = await new RolesDialog(page).expectOpen();
+  await dialog.addRole(role);
+  await dialog.confirm();
+}

--- a/e2e/components/roles-dialog.mjs
+++ b/e2e/components/roles-dialog.mjs
@@ -43,7 +43,9 @@ export class RolesDialog {
 // resulting row state themselves (durable for People, transient for ManageAccount
 // — see confirm()).
 export async function editRolesByEmail(page, email, role) {
-  await page.getByRole('row', { name: new RegExp(email) }).getByRole('button', { name: 'Edit' }).click();
+  // Plain string => case-insensitive substring match on the row's accessible
+  // name, with '.'/'+' literal (a RegExp would treat them as metacharacters).
+  await page.getByRole('row', { name: email }).getByRole('button', { name: 'Edit' }).click();
   const dialog = await new RolesDialog(page).expectOpen();
   await dialog.addRole(role);
   await dialog.confirm();

--- a/e2e/components/select.mjs
+++ b/e2e/components/select.mjs
@@ -1,0 +1,42 @@
+// Component object for an Element Plus el-select.
+//
+// Two EP facts drive this design (Q3):
+//  - The dropdown options render in a body-level overlay (.el-select-dropdown),
+//    NOT inside the trigger — so option clicks are scoped to the page.
+//  - An el-form-item's <label> is a sibling of the control and is not
+//    associated (no for/id) with the el-select (which is a <div>, not a native
+//    input), so getByLabel cannot target it. We scope by the form-item's
+//    visible label text instead.
+
+export class Select {
+  // `trigger` is a Locator for the .el-select element to open.
+  constructor(page, trigger) {
+    this.page = page;
+    this.trigger = trigger;
+  }
+
+  // A Select scoped to an el-form-item by its visible label, within a
+  // form/dialog `scope` Locator. e.g. Select.inForm(dialog, 'Roles').
+  static inForm(scope, label) {
+    const trigger = scope.locator('.el-form-item', { hasText: label }).locator('.el-select');
+    return new Select(scope.page(), trigger);
+  }
+
+  // Open the dropdown and click an option by its text.
+  async #open(optionText) {
+    await this.trigger.click();
+    await this.page.locator('.el-select-dropdown__item', { hasText: optionText }).click();
+  }
+
+  // Single-select: pick one option (the overlay auto-closes on click).
+  async choose(optionText) {
+    await this.#open(optionText);
+  }
+
+  // Multi-select: add an option, then dismiss the still-open overlay so a
+  // following footer button (Confirm, etc.) is clickable.
+  async add(optionText) {
+    await this.#open(optionText);
+    await this.page.keyboard.press('Escape');
+  }
+}

--- a/e2e/courses.spec.mjs
+++ b/e2e/courses.spec.mjs
@@ -1,53 +1,43 @@
 import { test, expect } from './fixtures.mjs';
+import { SEED } from './seed-data.mjs';
 
 // Plan tasks 6b (course list per role) and 7 (creator creates a course).
 // AllCourse.vue renders each enrolled course as a card with an <h3> name and
 // gates "Start a New Course" behind the `creator` system role.
 
-function e2eCourseCard(page) {
-  return page.getByRole('heading', { level: 3, name: 'E2E Course' });
-}
-
 test.describe('Course list (task 6b)', () => {
   for (const role of ['owner', 'instructor', 'staff', 'student']) {
-    test(`${role} sees the E2E Course they are enrolled in`, async ({ page, loginAs }) => {
+    test(`${role} sees the E2E Course they are enrolled in`, async ({ loginAs, coursesPage }) => {
       await loginAs(role);
-      await page.goto('/');
-      await expect(e2eCourseCard(page)).toBeVisible();
+      await coursesPage.goto();
+      await expect(coursesPage.courseCard(SEED.course.name)).toBeVisible();
     });
   }
 
-  test('creator (not enrolled in E2E Course) does not see it', async ({ page, loginAs }) => {
+  test('creator (not enrolled in E2E Course) does not see it', async ({ loginAs, coursesPage }) => {
     await loginAs('creator');
-    await page.goto('/');
-    // Wait for the list to load: the welcome header is rendered from the session
+    await coursesPage.goto();
+    // Wait for the list to load: the welcome header renders from the session
     // immediately, and the course fetch resolves after.
-    await expect(page.getByRole('heading', { name: /Welcome Back/ })).toBeVisible();
-    await expect(e2eCourseCard(page)).toHaveCount(0);
+    await expect(coursesPage.welcomeHeading).toBeVisible();
+    await expect(coursesPage.courseCard(SEED.course.name)).toHaveCount(0);
   });
 });
 
 test.describe('Create course (task 7)', () => {
-  test('creator can create a course and it appears in the list', async ({ page, loginAs }) => {
+  test('creator can create a course and it appears in the list', async ({ loginAs, coursesPage }) => {
     await loginAs('creator');
-    await page.goto('/');
+    await coursesPage.goto();
 
     const courseName = `PW Course ${Date.now()}`;
+    await coursesPage.startNewCourse(courseName);
 
-    await page.getByRole('button', { name: 'Start a New Course' }).click();
-
-    const dialog = page.getByRole('dialog', { name: 'Create Course' });
-    await expect(dialog).toBeVisible();
-    await dialog.locator('.el-form-item', { hasText: 'Name' }).getByRole('textbox').fill(courseName);
-    await dialog.getByRole('button', { name: 'Confirm' }).click();
-
-    await expect(dialog).toBeHidden();
-    await expect(page.getByRole('heading', { level: 3, name: courseName })).toBeVisible();
+    await expect(coursesPage.courseCard(courseName)).toBeVisible();
   });
 
-  test('non-creator (student) does not see the create-course button', async ({ page, loginAs }) => {
+  test('non-creator (student) does not see the create-course button', async ({ loginAs, coursesPage }) => {
     await loginAs('student');
-    await page.goto('/');
-    await expect(page.getByRole('button', { name: 'Start a New Course' })).toHaveCount(0);
+    await coursesPage.goto();
+    await expect(coursesPage.newCourseButton).toHaveCount(0);
   });
 });

--- a/e2e/courses.spec.mjs
+++ b/e2e/courses.spec.mjs
@@ -1,0 +1,53 @@
+import { test, expect } from './fixtures.mjs';
+
+// Plan tasks 6b (course list per role) and 7 (creator creates a course).
+// AllCourse.vue renders each enrolled course as a card with an <h3> name and
+// gates "Start a New Course" behind the `creator` system role.
+
+function e2eCourseCard(page) {
+  return page.getByRole('heading', { level: 3, name: 'E2E Course' });
+}
+
+test.describe('Course list (task 6b)', () => {
+  for (const role of ['owner', 'instructor', 'staff', 'student']) {
+    test(`${role} sees the E2E Course they are enrolled in`, async ({ page, loginAs }) => {
+      await loginAs(role);
+      await page.goto('/');
+      await expect(e2eCourseCard(page)).toBeVisible();
+    });
+  }
+
+  test('creator (not enrolled in E2E Course) does not see it', async ({ page, loginAs }) => {
+    await loginAs('creator');
+    await page.goto('/');
+    // Wait for the list to load: the welcome header is rendered from the session
+    // immediately, and the course fetch resolves after.
+    await expect(page.getByRole('heading', { name: /Welcome Back/ })).toBeVisible();
+    await expect(e2eCourseCard(page)).toHaveCount(0);
+  });
+});
+
+test.describe('Create course (task 7)', () => {
+  test('creator can create a course and it appears in the list', async ({ page, loginAs }) => {
+    await loginAs('creator');
+    await page.goto('/');
+
+    const courseName = `PW Course ${Date.now()}`;
+
+    await page.getByRole('button', { name: 'Start a New Course' }).click();
+
+    const dialog = page.getByRole('dialog', { name: 'Create Course' });
+    await expect(dialog).toBeVisible();
+    await dialog.locator('.el-form-item', { hasText: 'Name' }).getByRole('textbox').fill(courseName);
+    await dialog.getByRole('button', { name: 'Confirm' }).click();
+
+    await expect(dialog).toBeHidden();
+    await expect(page.getByRole('heading', { level: 3, name: courseName })).toBeVisible();
+  });
+
+  test('non-creator (student) does not see the create-course button', async ({ page, loginAs }) => {
+    await loginAs('student');
+    await page.goto('/');
+    await expect(page.getByRole('button', { name: 'Start a New Course' })).toHaveCount(0);
+  });
+});

--- a/e2e/fixtures.mjs
+++ b/e2e/fixtures.mjs
@@ -1,0 +1,54 @@
+import { test as base, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+import { CREDENTIALS_PATH } from './global-setup.mjs';
+
+// Cookie-injection login for E2E. global-setup.mjs has already minted a real
+// credential per seeded `@e2e.test` account into e2e/.auth/credentials.json;
+// here we read that file and set the 5 session cookies the app expects
+// (frontend_app/lib/session.js), so the SPA boots already authenticated.
+//
+// Usage:
+//   import { test, expect } from './fixtures.mjs';
+//   test('...', async ({ page, loginAs }) => {
+//     await loginAs('owner');          // owner | instructor | staff | student | creator | admin
+//     await page.goto('/');
+//   });
+
+let cache;
+
+function credentialFor(role) {
+  cache ??= JSON.parse(readFileSync(CREDENTIALS_PATH, 'utf8'));
+  const entry = cache[role];
+  if (!entry) {
+    throw new Error(
+      `No E2E credential for role "${role}". Available: ${Object.keys(cache).join(', ')}`,
+    );
+  }
+  return entry;
+}
+
+export const ROLES = ['admin', 'creator', 'owner', 'instructor', 'staff', 'student'];
+
+export const test = base.extend({
+  // loginAs(role) sets the session cookies on the browser context. Call it
+  // before page.goto() so the SPA reads the session on first load. Returns the
+  // account record ({ id, name, email, roles, ... }) for assertions.
+  loginAs: async ({ context, baseURL }, use) => {
+    const { hostname } = new URL(baseURL);
+    const setSession = async (role) => {
+      const account = credentialFor(role);
+      const common = { domain: hostname, path: '/', sameSite: 'Lax' };
+      await context.addCookies([
+        { name: 'account_id', value: String(account.id), ...common },
+        { name: 'account_roles', value: account.roles.join(','), ...common },
+        { name: 'account_credential', value: account.credential, ...common },
+        { name: 'account_img', value: account.avatar ?? '', ...common },
+        { name: 'account_name', value: account.name ?? '', ...common },
+      ]);
+      return account;
+    };
+    await use(setSession);
+  },
+});
+
+export { expect };

--- a/e2e/fixtures.mjs
+++ b/e2e/fixtures.mjs
@@ -1,6 +1,15 @@
 import { test as base, expect } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { CREDENTIALS_PATH } from './global-setup.mjs';
+import { CoursesPage } from './pages/courses-page.mjs';
+import { SingleCoursePage } from './pages/single-course-page.mjs';
+import { PeoplePage } from './pages/people-page.mjs';
+import { AttendanceEventsPage } from './pages/attendance-events-page.mjs';
+import { AssignmentsPage } from './pages/assignments-page.mjs';
+import { LocationsPage } from './pages/locations-page.mjs';
+import { ManageAccountPage } from './pages/manage-account-page.mjs';
+import { LoginPage } from './pages/login-page.mjs';
+import { AppShell } from './pages/app-shell.mjs';
 
 // Cookie-injection login for E2E. global-setup.mjs has already minted a real
 // credential per seeded `@e2e.test` account into e2e/.auth/credentials.json;
@@ -49,6 +58,19 @@ export const test = base.extend({
     };
     await use(setSession);
   },
+
+  // Page objects, injected per test. Specs receive these instead of
+  // constructing them or touching selectors directly.
+  coursesPage: async ({ page }, use) => use(new CoursesPage(page)),
+  singleCoursePage: async ({ page }, use) => use(new SingleCoursePage(page)),
+  peoplePage: async ({ page }, use) => use(new PeoplePage(page)),
+  attendanceEventsPage: async ({ page }, use) => use(new AttendanceEventsPage(page)),
+  assignmentsPage: async ({ page }, use) => use(new AssignmentsPage(page)),
+  locationsPage: async ({ page }, use) => use(new LocationsPage(page)),
+  manageAccountPage: async ({ page }, use) => use(new ManageAccountPage(page)),
+  // LoginPage is anemic (URL-only) and needs no page handle.
+  loginPage: async ({}, use) => use(new LoginPage()),
+  appShell: async ({ page }, use) => use(new AppShell(page)),
 });
 
 export { expect };

--- a/e2e/global-setup.mjs
+++ b/e2e/global-setup.mjs
@@ -1,0 +1,44 @@
+import { execSync } from 'node:child_process';
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Playwright global setup: mint a login credential for every seeded
+// `@e2e.test` account in a single Ruby boot and cache them to
+// e2e/.auth/credentials.json. The loginAs() fixture reads this file and sets
+// the session cookies — no Google OAuth, no per-test rake invocation.
+//
+// Requires the test DB to be seeded already (rake spec:e2e handles that). This
+// does no HTTP, so it is independent of the webServer start order.
+
+const here = dirname(fileURLToPath(import.meta.url));
+export const CREDENTIALS_PATH = resolve(here, '.auth/credentials.json');
+
+export default function globalSetup() {
+  const raw = execSync('RACK_ENV=test bundle exec rake generate:e2e_credentials', {
+    cwd: resolve(here, '..'),
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  // The rake task prints one JSON object on its own line; ignore any boot noise.
+  const jsonLine = raw
+    .trim()
+    .split('\n')
+    .reverse()
+    .find((line) => line.trim().startsWith('{'));
+
+  if (!jsonLine) {
+    throw new Error(`Could not find credential JSON in rake output:\n${raw}`);
+  }
+
+  const credentials = JSON.parse(jsonLine);
+  const roles = Object.keys(credentials);
+  if (roles.length === 0) {
+    throw new Error('No @e2e.test accounts found — is the test DB seeded?');
+  }
+
+  mkdirSync(dirname(CREDENTIALS_PATH), { recursive: true });
+  writeFileSync(CREDENTIALS_PATH, JSON.stringify(credentials, null, 2));
+  console.log(`[e2e] minted credentials for roles: ${roles.join(', ')}`);
+}

--- a/e2e/helpers.mjs
+++ b/e2e/helpers.mjs
@@ -1,14 +1,18 @@
 import { expect } from '@playwright/test';
+import { CoursesPage } from './pages/courses-page.mjs';
+import { SEED } from './seed-data.mjs';
 
-// Shared navigation helpers for E2E specs.
+// Pure navigation helpers shared by the page objects (e2e/pages/). Selector
+// quarantine lives in the page/component objects; these are URL/role-locator
+// navigation only.
 
 // Open the seeded "E2E Course" by clicking its card on the home page, so the
 // course id is never hardcoded. Lands on /course/:id/attendance (or, for
 // non-managers, wherever redirectIfNotManager sends them).
 export async function openE2eCourse(page) {
-  await page.goto('/');
-  await page.getByRole('heading', { level: 3, name: 'E2E Course' }).click();
-  await page.waitForURL(/\/course\/\d+\//);
+  const courses = new CoursesPage(page);
+  await courses.goto();
+  await courses.openCourse(SEED.course.name);
 }
 
 // Open a management tab (Attendance Events | Locations | People | Assignments)
@@ -24,12 +28,4 @@ export async function openCourseTab(page, tabName) {
 // parallel workers (worker index keeps concurrent workers distinct).
 export function uniqueEmail(prefix, workerIndex = 0) {
   return `${prefix}-${workerIndex}-${Date.now()}@e2e.test`;
-}
-
-// Pick an option from an already-opened Element Plus dropdown (el-select).
-// Options render in a body-level overlay, so this is scoped to the page, not
-// the trigger. `scope` clicks the trigger first (defaults to the page).
-export async function chooseOption(page, optionText, trigger) {
-  if (trigger) await trigger.click();
-  await page.locator('.el-select-dropdown__item', { hasText: optionText }).click();
 }

--- a/e2e/helpers.mjs
+++ b/e2e/helpers.mjs
@@ -1,0 +1,35 @@
+import { expect } from '@playwright/test';
+
+// Shared navigation helpers for E2E specs.
+
+// Open the seeded "E2E Course" by clicking its card on the home page, so the
+// course id is never hardcoded. Lands on /course/:id/attendance (or, for
+// non-managers, wherever redirectIfNotManager sends them).
+export async function openE2eCourse(page) {
+  await page.goto('/');
+  await page.getByRole('heading', { level: 3, name: 'E2E Course' }).click();
+  await page.waitForURL(/\/course\/\d+\//);
+}
+
+// Open a management tab (Attendance Events | Locations | People | Assignments)
+// from within the course. Manager-only tabs require a teaching role.
+export async function openCourseTab(page, tabName) {
+  await openE2eCourse(page);
+  const tab = page.getByRole('link', { name: tabName });
+  await expect(tab).toBeVisible();
+  await tab.click();
+}
+
+// A unique @e2e.test email so enrollment specs never collide across runs or
+// parallel workers (worker index keeps concurrent workers distinct).
+export function uniqueEmail(prefix, workerIndex = 0) {
+  return `${prefix}-${workerIndex}-${Date.now()}@e2e.test`;
+}
+
+// Pick an option from an already-opened Element Plus dropdown (el-select).
+// Options render in a body-level overlay, so this is scoped to the page, not
+// the trigger. `scope` clicks the trigger first (defaults to the page).
+export async function chooseOption(page, optionText, trigger) {
+  if (trigger) await trigger.click();
+  await page.locator('.el-select-dropdown__item', { hasText: optionText }).click();
+}

--- a/e2e/locations.spec.mjs
+++ b/e2e/locations.spec.mjs
@@ -1,5 +1,5 @@
 import { test, expect } from './fixtures.mjs';
-import { openCourseTab } from './helpers.mjs';
+import { SEED } from './seed-data.mjs';
 
 // Plan task 14 — Locations (manager). The list + delete are plain DOM, but
 // CREATE/UPDATE happen by clicking a Google Maps widget to pick coordinates
@@ -7,24 +7,22 @@ import { openCourseTab } from './helpers.mjs';
 // headless E2E — so those are out of scope here (noted in the plan). We cover
 // the manager-visible list, the create affordance, and a real delete.
 
-test('owner sees the locations list and create affordance', async ({ page, loginAs }) => {
+test('owner sees the locations list and create affordance', async ({ loginAs, locationsPage }) => {
   await loginAs('owner');
-  await openCourseTab(page, 'Locations');
+  await locationsPage.open();
 
-  await expect(page.locator('.location-item', { hasText: 'E2E Main Hall' })).toBeVisible();
-  await expect(page.getByRole('button', { name: 'Create New' })).toBeVisible();
-  await expect(page.getByPlaceholder('Enter a name of the location')).toBeVisible();
+  await expect(locationsPage.card(SEED.mainHall.name)).toBeVisible();
+  await expect(locationsPage.createButton).toBeVisible();
+  await expect(locationsPage.nameInput).toBeVisible();
 });
 
-test('owner can delete a location', async ({ page, loginAs }) => {
+test('owner can delete a location', async ({ loginAs, locationsPage }) => {
   await loginAs('owner');
-  await openCourseTab(page, 'Locations');
+  await locationsPage.open();
 
   // Delete the event-free spare location (deleting E2E Main Hall would cascade
   // the seeded attendance event). Assumes fresh DB — gone on re-run.
-  const spare = page.locator('.location-item', { hasText: 'E2E Spare Room' });
-  await expect(spare).toBeVisible();
-  await spare.getByRole('button').last().click(); // trash (Delete) is the last button in the row
-
-  await expect(page.locator('.location-item', { hasText: 'E2E Spare Room' })).toHaveCount(0);
+  await expect(locationsPage.card(SEED.spareRoom.name)).toBeVisible();
+  await locationsPage.delete(SEED.spareRoom.name);
+  await expect(locationsPage.card(SEED.spareRoom.name)).toHaveCount(0);
 });

--- a/e2e/locations.spec.mjs
+++ b/e2e/locations.spec.mjs
@@ -1,0 +1,30 @@
+import { test, expect } from './fixtures.mjs';
+import { openCourseTab } from './helpers.mjs';
+
+// Plan task 14 — Locations (manager). The list + delete are plain DOM, but
+// CREATE/UPDATE happen by clicking a Google Maps widget to pick coordinates
+// (see LocationCard.vue), which needs a live Maps API key and can't run in
+// headless E2E — so those are out of scope here (noted in the plan). We cover
+// the manager-visible list, the create affordance, and a real delete.
+
+test('owner sees the locations list and create affordance', async ({ page, loginAs }) => {
+  await loginAs('owner');
+  await openCourseTab(page, 'Locations');
+
+  await expect(page.locator('.location-item', { hasText: 'E2E Main Hall' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Create New' })).toBeVisible();
+  await expect(page.getByPlaceholder('Enter a name of the location')).toBeVisible();
+});
+
+test('owner can delete a location', async ({ page, loginAs }) => {
+  await loginAs('owner');
+  await openCourseTab(page, 'Locations');
+
+  // Delete the event-free spare location (deleting E2E Main Hall would cascade
+  // the seeded attendance event). Assumes fresh DB — gone on re-run.
+  const spare = page.locator('.location-item', { hasText: 'E2E Spare Room' });
+  await expect(spare).toBeVisible();
+  await spare.getByRole('button').last().click(); // trash (Delete) is the last button in the row
+
+  await expect(page.locator('.location-item', { hasText: 'E2E Spare Room' })).toHaveCount(0);
+});

--- a/e2e/manage-account.spec.mjs
+++ b/e2e/manage-account.spec.mjs
@@ -1,35 +1,26 @@
 import { test, expect } from './fixtures.mjs';
+import { SEED } from './seed-data.mjs';
 
 // Plan task 13 — admin account management. Admin opens /manage-account and
 // changes a target user's system roles via the Edit dialog (PUT /account/:id).
 
-test('admin can change a user system role', async ({ page, loginAs }) => {
+test('admin can change a user system role', async ({ loginAs, manageAccountPage }) => {
   await loginAs('admin');
-  await page.goto('/manage-account');
-
-  await expect(page.getByText('Accounts Management')).toBeVisible();
+  await manageAccountPage.goto();
 
   // Target a course-role account whose system roles other specs don't read from
   // the DB (they read the cookie), so this change is isolated.
-  const row = page.getByRole('row', { name: /e2e-staff@e2e\.test/ });
-  await expect(row).toBeVisible();
+  const email = SEED.accounts.staff.email;
+  await expect(manageAccountPage.row(email)).toBeVisible();
 
-  await row.getByRole('button', { name: 'Edit' }).click();
-  const dlg = page.getByRole('dialog', { name: 'Edit Account' });
-  await expect(dlg).toBeVisible();
+  await manageAccountPage.addRole(email, 'Creator');
 
-  // Add the Creator system role.
-  await dlg.locator('.el-form-item', { hasText: 'Roles' }).locator('.el-select').click();
-  await page.locator('.el-select-dropdown__item', { hasText: 'Creator' }).click();
-  await page.keyboard.press('Escape');
-  await dlg.getByRole('button', { name: 'Confirm' }).click();
-
-  await expect(page.getByRole('row', { name: /e2e-staff@e2e\.test/ })).toContainText('creator');
+  await expect(manageAccountPage.row(email)).toContainText('creator');
 });
 
-test('non-admin sees no Account Management menu item', async ({ page, loginAs }) => {
+test('non-admin sees no Account Management menu item', async ({ loginAs, coursesPage, appShell }) => {
   await loginAs('owner');
-  await page.goto('/');
+  await coursesPage.goto();
   // The admin side menu / popover entry is gated on the admin role.
-  await expect(page.getByText('Account Management')).toHaveCount(0);
+  await expect(appShell.accountManagementMenu()).toHaveCount(0);
 });

--- a/e2e/manage-account.spec.mjs
+++ b/e2e/manage-account.spec.mjs
@@ -1,0 +1,35 @@
+import { test, expect } from './fixtures.mjs';
+
+// Plan task 13 — admin account management. Admin opens /manage-account and
+// changes a target user's system roles via the Edit dialog (PUT /account/:id).
+
+test('admin can change a user system role', async ({ page, loginAs }) => {
+  await loginAs('admin');
+  await page.goto('/manage-account');
+
+  await expect(page.getByText('Accounts Management')).toBeVisible();
+
+  // Target a course-role account whose system roles other specs don't read from
+  // the DB (they read the cookie), so this change is isolated.
+  const row = page.getByRole('row', { name: /e2e-staff@e2e\.test/ });
+  await expect(row).toBeVisible();
+
+  await row.getByRole('button', { name: 'Edit' }).click();
+  const dlg = page.getByRole('dialog', { name: 'Edit Account' });
+  await expect(dlg).toBeVisible();
+
+  // Add the Creator system role.
+  await dlg.locator('.el-form-item', { hasText: 'Roles' }).locator('.el-select').click();
+  await page.locator('.el-select-dropdown__item', { hasText: 'Creator' }).click();
+  await page.keyboard.press('Escape');
+  await dlg.getByRole('button', { name: 'Confirm' }).click();
+
+  await expect(page.getByRole('row', { name: /e2e-staff@e2e\.test/ })).toContainText('creator');
+});
+
+test('non-admin sees no Account Management menu item', async ({ page, loginAs }) => {
+  await loginAs('owner');
+  await page.goto('/');
+  // The admin side menu / popover entry is gated on the admin role.
+  await expect(page.getByText('Account Management')).toHaveCount(0);
+});

--- a/e2e/pages/app-shell.mjs
+++ b/e2e/pages/app-shell.mjs
@@ -1,0 +1,19 @@
+// Global app chrome present on every authenticated page: the avatar menu
+// (logout) and the admin-only nav entries.
+export class AppShell {
+  constructor(page) {
+    this.page = page;
+  }
+
+  // Logout lives in the avatar popover (renders because E2E accounts have an
+  // avatar). Hover to reveal it, then click.
+  async logout() {
+    await this.page.locator('.avatar-btn').first().hover();
+    await this.page.getByText('Logout', { exact: true }).click();
+  }
+
+  // The admin-only "Account Management" nav entry.
+  accountManagementMenu() {
+    return this.page.getByText('Account Management');
+  }
+}

--- a/e2e/pages/assignments-page.mjs
+++ b/e2e/pages/assignments-page.mjs
@@ -1,0 +1,83 @@
+import { expect } from '@playwright/test';
+import { Select } from '../components/select.mjs';
+import { openCourseTab, openE2eCourse } from '../helpers.mjs';
+
+// The Assignments view. Managers reach it via the management tab and get the
+// full lifecycle (create / publish / unpublish / delete); students are routed
+// here read-only by redirectIfNotManager and can submit to published ones.
+export class AssignmentsPage {
+  constructor(page) {
+    this.page = page;
+    this.createCard = page.locator('.assignment-item', { hasText: 'Create Assignment' });
+    // Every assignment card's action group (Edit/Publish/Delete); absent in the
+    // student read-only view.
+    this.actionGroups = page.locator('.assignment-item .assignment-actions');
+  }
+
+  // Manager entry: the Assignments management tab.
+  async open() {
+    await openCourseTab(this.page, 'Assignments');
+    return this;
+  }
+
+  // Student entry: redirectIfNotManager lands them on the read-only view.
+  async openAsStudent() {
+    await openE2eCourse(this.page);
+    return this;
+  }
+
+  card(title) {
+    return this.page.locator('.assignment-item', { hasText: title });
+  }
+
+  status(title) {
+    return this.card(title).locator('.el-tag');
+  }
+
+  // Within an assignment card the actions are [Edit, Publish|Unpublish, Delete];
+  // index 1 is the publish/unpublish toggle regardless of title attributes.
+  #statusToggle(title) {
+    return this.card(title).locator('.assignment-actions .el-icon').nth(1);
+  }
+
+  async create(title, { urlRequirement } = {}) {
+    await this.createCard.click();
+    const dlg = this.page.getByRole('dialog', { name: 'Create Assignment' });
+    await expect(dlg).toBeVisible();
+    await dlg.getByPlaceholder('Assignment title').fill(title);
+
+    if (urlRequirement) {
+      // The dialog seeds one (file, empty-description) requirement row. Switch
+      // it to a URL requirement so a student can submit without a file upload.
+      const row = dlg.locator('.requirement-row').first();
+      await new Select(this.page, row.locator('.el-select')).choose('URL');
+      await row.getByPlaceholder(/Description/).fill(urlRequirement);
+    }
+
+    await dlg.getByRole('button', { name: 'Create' }).click();
+    await expect(dlg).toBeHidden();
+  }
+
+  async publish(title) {
+    await this.#statusToggle(title).click();
+    await this.page.getByRole('button', { name: 'Publish' }).click();
+    await expect(this.status(title)).toHaveText('published');
+  }
+
+  async unpublish(title) {
+    await this.#statusToggle(title).click();
+    await this.page.getByRole('button', { name: 'Unpublish' }).click();
+    await expect(this.status(title)).toHaveText('draft');
+  }
+
+  // Open a published assignment and submit a URL; returns the dialog Locator so
+  // callers can assert on its post-submit state.
+  async submitUrl(title, url) {
+    await this.card(title).click();
+    const dlg = this.page.getByRole('dialog', { name: title });
+    await expect(dlg).toBeVisible();
+    await dlg.getByPlaceholder('Enter URL').fill(url);
+    await dlg.getByRole('button', { name: 'Submit', exact: true }).click();
+    return dlg;
+  }
+}

--- a/e2e/pages/attendance-events-page.mjs
+++ b/e2e/pages/attendance-events-page.mjs
@@ -1,0 +1,47 @@
+import { expect } from '@playwright/test';
+import { Select } from '../components/select.mjs';
+import { openCourseTab } from '../helpers.mjs';
+
+// The Attendance Events management tab (manager-only). Download/create controls
+// plus the create-event dialog and per-event delete.
+export class AttendanceEventsPage {
+  constructor(page) {
+    this.page = page;
+    this.downloadButton = page.getByRole('button', { name: 'Download Record' });
+    this.createCard = page.locator('.event-item', { hasText: 'Create Event' });
+  }
+
+  async open() {
+    await openCourseTab(this.page, 'Attendance Events');
+    return this;
+  }
+
+  card(name) {
+    return this.page.locator('.event-item', { hasText: name });
+  }
+
+  async createEvent(name, { location, start, end }) {
+    await this.createCard.click();
+    const dlg = this.page.getByRole('dialog', { name: 'Create Attendance Event' });
+    await expect(dlg).toBeVisible();
+
+    await dlg.getByPlaceholder('e.g. Week 08 Lecture').fill(name);
+    await Select.inForm(dlg, 'Location').choose(location);
+
+    // Datetime pickers accept typed "YYYY-MM-DD HH:mm:ss"; Enter commits.
+    const startInput = dlg.getByPlaceholder('Select start time');
+    await startInput.fill(start);
+    await startInput.press('Enter');
+    const endInput = dlg.getByPlaceholder('Select end time');
+    await endInput.fill(end);
+    await endInput.press('Enter');
+
+    await dlg.getByRole('button', { name: 'Create event' }).click();
+    await expect(dlg).toBeHidden();
+  }
+
+  async deleteEvent(name) {
+    // The trash icon is the last el-icon in the event card.
+    await this.card(name).locator('.el-icon').last().click();
+  }
+}

--- a/e2e/pages/courses-page.mjs
+++ b/e2e/pages/courses-page.mjs
@@ -1,0 +1,54 @@
+import { expect } from '@playwright/test';
+
+// The home page (AllCourse.vue): the enrolled-course list, the creator-only
+// "Start a New Course" flow, and the active-event cards a student checks in
+// from. Course names render as <h3> headings; both course cards and event
+// cards use the .course-item class.
+export class CoursesPage {
+  // The URL of a single course once a card is opened (/course/:id/...). Static
+  // because helpers.openE2eCourse needs it without an instance; it is the one
+  // route literal shared beyond a spec, so it lives here once.
+  static courseUrl = /\/course\/\d+\//;
+
+  constructor(page) {
+    this.page = page;
+    // The named course-list route. The router serves the list at both / (which
+    // goto() uses) and /course; this is the protected route auth's logged-out
+    // redirect probe hits.
+    this.path = '/course';
+    this.welcomeHeading = page.getByRole('heading', { name: /Welcome Back/ });
+    this.newCourseButton = page.getByRole('button', { name: 'Start a New Course' });
+  }
+
+  async goto() {
+    await this.page.goto('/');
+    return this;
+  }
+
+  courseCard(name) {
+    return this.page.getByRole('heading', { level: 3, name });
+  }
+
+  async openCourse(name) {
+    await this.courseCard(name).click();
+    await this.page.waitForURL(CoursesPage.courseUrl);
+  }
+
+  async startNewCourse(name) {
+    await this.newCourseButton.click();
+    const dialog = this.page.getByRole('dialog', { name: 'Create Course' });
+    await expect(dialog).toBeVisible();
+    await dialog.locator('.el-form-item', { hasText: 'Name' }).getByRole('textbox').fill(name);
+    await dialog.getByRole('button', { name: 'Confirm' }).click();
+    await expect(dialog).toBeHidden();
+  }
+
+  // Active-event card on the home page (events render as .course-item too).
+  eventCard(name) {
+    return this.page.locator('.course-item', { hasText: name });
+  }
+
+  async markAttendance(eventName) {
+    await this.eventCard(eventName).getByRole('button', { name: 'Mark Attendance' }).click();
+  }
+}

--- a/e2e/pages/locations-page.mjs
+++ b/e2e/pages/locations-page.mjs
@@ -1,0 +1,26 @@
+import { openCourseTab } from '../helpers.mjs';
+
+// LocationCard.vue — the Locations management tab. Create/update happen inside
+// a Google Maps widget (out of scope for headless E2E); here we cover the list,
+// the create affordance, and delete.
+export class LocationsPage {
+  constructor(page) {
+    this.page = page;
+    this.createButton = page.getByRole('button', { name: 'Create New' });
+    this.nameInput = page.getByPlaceholder('Enter a name of the location');
+  }
+
+  async open() {
+    await openCourseTab(this.page, 'Locations');
+    return this;
+  }
+
+  card(name) {
+    return this.page.locator('.location-item', { hasText: name });
+  }
+
+  async delete(name) {
+    // The trash (Delete) is the last button in the location row.
+    await this.card(name).getByRole('button').last().click();
+  }
+}

--- a/e2e/pages/login-page.mjs
+++ b/e2e/pages/login-page.mjs
@@ -1,0 +1,8 @@
+// LoginPage models ONLY the /login route. The Login.vue UI (the Google OAuth
+// button) is deliberately unmodeled: E2E auth uses cookie injection and bypasses
+// Google entirely (PLAN.test-ui Q5). This object's single `url` matcher is the
+// whole contract specs assert — "the app is on /login" — so its anemia is the
+// signal that login itself is out of scope here, not an oversight.
+export class LoginPage {
+  url = /\/login/;
+}

--- a/e2e/pages/manage-account-page.mjs
+++ b/e2e/pages/manage-account-page.mjs
@@ -1,0 +1,25 @@
+import { expect } from '@playwright/test';
+import { editRolesByEmail } from '../components/roles-dialog.mjs';
+
+// ManageAccount.vue (admin) — change a user's system roles via the shared
+// "Edit Account" dialog (PUT /account/:id).
+export class ManageAccountPage {
+  constructor(page) {
+    this.page = page;
+    this.title = page.getByText('Accounts Management');
+  }
+
+  async goto() {
+    await this.page.goto('/manage-account');
+    await expect(this.title).toBeVisible();
+    return this;
+  }
+
+  row(email) {
+    return this.page.getByRole('row', { name: new RegExp(email) });
+  }
+
+  async addRole(email, role) {
+    await editRolesByEmail(this.page, email, role);
+  }
+}

--- a/e2e/pages/manage-account-page.mjs
+++ b/e2e/pages/manage-account-page.mjs
@@ -16,7 +16,9 @@ export class ManageAccountPage {
   }
 
   row(email) {
-    return this.page.getByRole('row', { name: new RegExp(email) });
+    // Plain string => Playwright matches the accessible name case-insensitively
+    // as a substring, with '.'/'+' treated literally (a RegExp would not).
+    return this.page.getByRole('row', { name: email });
   }
 
   async addRole(email, role) {

--- a/e2e/pages/people-page.mjs
+++ b/e2e/pages/people-page.mjs
@@ -16,7 +16,9 @@ export class PeoplePage {
   }
 
   row(email) {
-    return this.page.getByRole('row', { name: new RegExp(email) });
+    // Plain string => Playwright matches the accessible name case-insensitively
+    // as a substring, with '.'/'+' treated literally (a RegExp would not).
+    return this.page.getByRole('row', { name: email });
   }
 
   async enroll(email) {

--- a/e2e/pages/people-page.mjs
+++ b/e2e/pages/people-page.mjs
@@ -1,0 +1,35 @@
+import { editRolesByEmail } from '../components/roles-dialog.mjs';
+import { openCourseTab } from '../helpers.mjs';
+
+// ManagePeopleCard.vue — the People management tab. Enroll by email (2-step
+// wizard, auto-creates the account as `member`), edit enrollment roles via the
+// shared "Edit Account" dialog, and delete an enrollment.
+export class PeoplePage {
+  constructor(page) {
+    this.page = page;
+    this.emailInput = page.getByPlaceholder('Enter email addresses (space-separated)');
+  }
+
+  async open() {
+    await openCourseTab(this.page, 'People');
+    return this;
+  }
+
+  row(email) {
+    return this.page.getByRole('row', { name: new RegExp(email) });
+  }
+
+  async enroll(email) {
+    await this.emailInput.fill(email);
+    await this.page.getByRole('button', { name: 'Next step' }).click();
+    await this.page.getByRole('button', { name: 'Enroll in Course' }).click();
+  }
+
+  async addRole(email, role) {
+    await editRolesByEmail(this.page, email, role);
+  }
+
+  async remove(email) {
+    await this.row(email).getByRole('button', { name: 'Delete' }).click();
+  }
+}

--- a/e2e/pages/single-course-page.mjs
+++ b/e2e/pages/single-course-page.mjs
@@ -1,0 +1,42 @@
+import { expect } from '@playwright/test';
+import { Select } from '../components/select.mjs';
+import { openE2eCourse } from '../helpers.mjs';
+
+// SingleCourse.vue: the per-course management shell. Managers (can_update) get
+// the tabbed view + a "view as role" switcher; non-teaching roles are sent to
+// the read-only assignments branch by redirectIfNotManager().
+//
+// NOTE: `.selecor-role-container` is a typo carried from the component
+// (SingleCourse.vue). Quarantined here so a future component fix is one line.
+export class SingleCoursePage {
+  constructor(page) {
+    this.page = page;
+    // Where redirectIfNotManager() sends a non-teaching role: the read-only
+    // assignments view of the course. Asserted from single-course + attendance
+    // -events specs, so the cross-spec contract lives once on this page object.
+    this.assignmentsUrl = /\/course\/\d+\/assignments/;
+    this.roleSwitcher = page.locator('.selecor-role-container .el-select');
+  }
+
+  async open() {
+    await openE2eCourse(this.page);
+    return this;
+  }
+
+  tab(name) {
+    return this.page.getByRole('link', { name });
+  }
+
+  async openTab(name) {
+    const tab = this.tab(name);
+    await expect(tab).toBeVisible();
+    await tab.click();
+  }
+
+  // Pick a role in the "view as" switcher and confirm the dialog. changeRole
+  // refetches data and shows a "Change to … view" toast.
+  async switchRole(role) {
+    await new Select(this.page, this.roleSwitcher).choose(role);
+    await this.page.getByRole('button', { name: 'OK' }).click();
+  }
+}

--- a/e2e/people.spec.mjs
+++ b/e2e/people.spec.mjs
@@ -1,0 +1,41 @@
+import { test, expect } from './fixtures.mjs';
+import { openCourseTab, uniqueEmail } from './helpers.mjs';
+
+// Plan task 9 — Manage People (owner/instructor). One sequential flow against a
+// throwaway enrollee so it never mutates the seeded enrollments other specs
+// rely on: enroll by email -> assign/extend role -> delete.
+
+test('owner can enroll, re-role, and remove a course member', async ({ page, loginAs }, testInfo) => {
+  await loginAs('owner');
+  await openCourseTab(page, 'People');
+
+  const email = uniqueEmail('e2e-enrollee', testInfo.workerIndex);
+
+  // --- Enroll (2-step wizard) -------------------------------------------------
+  await page.getByPlaceholder('Enter email addresses (space-separated)').fill(email);
+  await page.getByRole('button', { name: 'Next step' }).click();
+  await page.getByRole('button', { name: 'Enroll in Course' }).click();
+
+  const row = page.getByRole('row', { name: new RegExp(email) });
+  await expect(row).toBeVisible();
+  // New enrollees default to the student role.
+  await expect(row).toContainText('student');
+
+  // --- Re-role: add staff -----------------------------------------------------
+  await row.getByRole('button', { name: 'Edit' }).click();
+  const dialog = page.getByRole('dialog', { name: 'Edit Account' });
+  await expect(dialog).toBeVisible();
+
+  await dialog.locator('.el-form-item', { hasText: 'Roles' }).locator('.el-select').click();
+  await page.locator('.el-select-dropdown__item', { hasText: 'staff' }).click();
+  // Close the dropdown overlay before clicking Confirm.
+  await page.keyboard.press('Escape');
+  await dialog.getByRole('button', { name: 'Confirm' }).click();
+  await expect(dialog).toBeHidden();
+
+  await expect(page.getByRole('row', { name: new RegExp(email) })).toContainText('staff');
+
+  // --- Delete -----------------------------------------------------------------
+  await page.getByRole('row', { name: new RegExp(email) }).getByRole('button', { name: 'Delete' }).click();
+  await expect(page.getByRole('row', { name: new RegExp(email) })).toHaveCount(0);
+});

--- a/e2e/people.spec.mjs
+++ b/e2e/people.spec.mjs
@@ -1,41 +1,26 @@
 import { test, expect } from './fixtures.mjs';
-import { openCourseTab, uniqueEmail } from './helpers.mjs';
+import { uniqueEmail } from './helpers.mjs';
 
 // Plan task 9 — Manage People (owner/instructor). One sequential flow against a
 // throwaway enrollee so it never mutates the seeded enrollments other specs
 // rely on: enroll by email -> assign/extend role -> delete.
 
-test('owner can enroll, re-role, and remove a course member', async ({ page, loginAs }, testInfo) => {
+test('owner can enroll, re-role, and remove a course member', async ({ loginAs, peoplePage }, testInfo) => {
   await loginAs('owner');
-  await openCourseTab(page, 'People');
+  await peoplePage.open();
 
   const email = uniqueEmail('e2e-enrollee', testInfo.workerIndex);
 
   // --- Enroll (2-step wizard) -------------------------------------------------
-  await page.getByPlaceholder('Enter email addresses (space-separated)').fill(email);
-  await page.getByRole('button', { name: 'Next step' }).click();
-  await page.getByRole('button', { name: 'Enroll in Course' }).click();
-
-  const row = page.getByRole('row', { name: new RegExp(email) });
-  await expect(row).toBeVisible();
+  await peoplePage.enroll(email);
   // New enrollees default to the student role.
-  await expect(row).toContainText('student');
+  await expect(peoplePage.row(email)).toContainText('student');
 
   // --- Re-role: add staff -----------------------------------------------------
-  await row.getByRole('button', { name: 'Edit' }).click();
-  const dialog = page.getByRole('dialog', { name: 'Edit Account' });
-  await expect(dialog).toBeVisible();
-
-  await dialog.locator('.el-form-item', { hasText: 'Roles' }).locator('.el-select').click();
-  await page.locator('.el-select-dropdown__item', { hasText: 'staff' }).click();
-  // Close the dropdown overlay before clicking Confirm.
-  await page.keyboard.press('Escape');
-  await dialog.getByRole('button', { name: 'Confirm' }).click();
-  await expect(dialog).toBeHidden();
-
-  await expect(page.getByRole('row', { name: new RegExp(email) })).toContainText('staff');
+  await peoplePage.addRole(email, 'staff');
+  await expect(peoplePage.row(email)).toContainText('staff');
 
   // --- Delete -----------------------------------------------------------------
-  await page.getByRole('row', { name: new RegExp(email) }).getByRole('button', { name: 'Delete' }).click();
-  await expect(page.getByRole('row', { name: new RegExp(email) })).toHaveCount(0);
+  await peoplePage.remove(email);
+  await expect(peoplePage.row(email)).toHaveCount(0);
 });

--- a/e2e/seed-data.mjs
+++ b/e2e/seed-data.mjs
@@ -1,0 +1,43 @@
+import { execSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// Seed-reference data for the specs, sourced from the SAME Ruby fixtures the DB
+// seed uses (Tyto::E2EFixtures). We shell out to `rake generate:e2e_seed_data`
+// — a pure-data task, no app boot, no DB — and parse its one JSON line, so the
+// specs and the seeded course/location/event can never drift.
+//
+// This runs eagerly at import (not lazily like credentials.json): some values
+// are used at Playwright *collection* time — e.g. `test.use({ geolocation })`
+// and the live-session name — which is before global setup runs. Node caches
+// the module, so the rake task is invoked once per `playwright test` process.
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+function loadSeedData() {
+  const raw = execSync('bundle exec rake generate:e2e_seed_data', {
+    cwd: resolve(here, '..'),
+    encoding: 'utf8',
+    maxBuffer: 10 * 1024 * 1024,
+  });
+
+  // The task prints one JSON object on its own line; ignore any boot noise.
+  const jsonLine = raw
+    .trim()
+    .split('\n')
+    .reverse()
+    .find((line) => line.trim().startsWith('{'));
+
+  if (!jsonLine) {
+    throw new Error(`Could not find seed-data JSON in rake output:\n${raw}`);
+  }
+  return JSON.parse(jsonLine);
+}
+
+// Shape (see Tyto::E2EFixtures.as_json):
+//   SEED.course.name        -> 'E2E Course'
+//   SEED.event.name         -> 'E2E Live Session'
+//   SEED.mainHall           -> { name, latitude, longitude }  (the geo-fence)
+//   SEED.spareRoom.name     -> 'E2E Spare Room'
+//   SEED.accounts.staff.email, ...
+export const SEED = loadSeedData();

--- a/e2e/single-course.spec.mjs
+++ b/e2e/single-course.spec.mjs
@@ -1,0 +1,53 @@
+import { test, expect } from './fixtures.mjs';
+import { openE2eCourse, chooseOption } from './helpers.mjs';
+
+// Plan tasks 8a (manager management view + "view as role" switcher) and
+// 8b (student is forced to the read-only branch via redirectIfNotManager).
+//
+// Course-list cards link everyone to /course/:id/attendance. Managers
+// (owner/instructor/staff — can_update) get the tabbed management branch with a
+// role switcher; students (can_update=false) are redirected to the Assignments
+// view. We reach the course by clicking its card so the id is never hardcoded.
+
+test.describe('SingleCourse management view (task 8a)', () => {
+  test('manager sees the management tabs and role switcher', async ({ page, loginAs }) => {
+    await loginAs('owner');
+    await openE2eCourse(page);
+
+    for (const tab of ['Attendance Events', 'Locations', 'People', 'Assignments']) {
+      await expect(page.getByRole('link', { name: tab })).toBeVisible();
+    }
+    await expect(page.locator('.selecor-role-container .el-select')).toBeVisible();
+  });
+
+  test('multi-role manager can switch the viewed role', async ({ page, loginAs }) => {
+    await loginAs('multi');
+    await openE2eCourse(page);
+
+    // Open the "View" role select and pick the student role.
+    await chooseOption(page, 'student', page.locator('.selecor-role-container .el-select'));
+
+    // changeRole pops a confirm dialog, then a success toast on OK.
+    await page.getByRole('button', { name: 'OK' }).click();
+    await expect(page.getByText('Change to student view').first()).toBeVisible();
+  });
+});
+
+test.describe('SingleCourse read-only branch (task 8b)', () => {
+  test('student is redirected from /attendance to the Assignments view', async ({ page, loginAs }) => {
+    await loginAs('student');
+    await openE2eCourse(page);
+
+    // redirectIfNotManager() replaces the management route with AssignmentsCard.
+    await expect(page).toHaveURL(/\/course\/\d+\/assignments/);
+  });
+
+  test('student does not see management tabs', async ({ page, loginAs }) => {
+    await loginAs('student');
+    await openE2eCourse(page);
+
+    await expect(page.getByRole('link', { name: 'People' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Locations' })).toHaveCount(0);
+    await expect(page.getByRole('link', { name: 'Attendance Events' })).toHaveCount(0);
+  });
+});

--- a/e2e/single-course.spec.mjs
+++ b/e2e/single-course.spec.mjs
@@ -1,5 +1,4 @@
 import { test, expect } from './fixtures.mjs';
-import { openE2eCourse, chooseOption } from './helpers.mjs';
 
 // Plan tasks 8a (manager management view + "view as role" switcher) and
 // 8b (student is forced to the read-only branch via redirectIfNotManager).
@@ -7,47 +6,43 @@ import { openE2eCourse, chooseOption } from './helpers.mjs';
 // Course-list cards link everyone to /course/:id/attendance. Managers
 // (owner/instructor/staff — can_update) get the tabbed management branch with a
 // role switcher; students (can_update=false) are redirected to the Assignments
-// view. We reach the course by clicking its card so the id is never hardcoded.
+// view.
 
 test.describe('SingleCourse management view (task 8a)', () => {
-  test('manager sees the management tabs and role switcher', async ({ page, loginAs }) => {
+  test('manager sees the management tabs and role switcher', async ({ loginAs, singleCoursePage }) => {
     await loginAs('owner');
-    await openE2eCourse(page);
+    await singleCoursePage.open();
 
     for (const tab of ['Attendance Events', 'Locations', 'People', 'Assignments']) {
-      await expect(page.getByRole('link', { name: tab })).toBeVisible();
+      await expect(singleCoursePage.tab(tab)).toBeVisible();
     }
-    await expect(page.locator('.selecor-role-container .el-select')).toBeVisible();
+    await expect(singleCoursePage.roleSwitcher).toBeVisible();
   });
 
-  test('multi-role manager can switch the viewed role', async ({ page, loginAs }) => {
+  test('multi-role manager can switch the viewed role', async ({ page, loginAs, singleCoursePage }) => {
     await loginAs('multi');
-    await openE2eCourse(page);
+    await singleCoursePage.open();
 
-    // Open the "View" role select and pick the student role.
-    await chooseOption(page, 'student', page.locator('.selecor-role-container .el-select'));
-
-    // changeRole pops a confirm dialog, then a success toast on OK.
-    await page.getByRole('button', { name: 'OK' }).click();
+    await singleCoursePage.switchRole('student');
     await expect(page.getByText('Change to student view').first()).toBeVisible();
   });
 });
 
 test.describe('SingleCourse read-only branch (task 8b)', () => {
-  test('student is redirected from /attendance to the Assignments view', async ({ page, loginAs }) => {
+  test('student is redirected from /attendance to the Assignments view', async ({ page, loginAs, singleCoursePage }) => {
     await loginAs('student');
-    await openE2eCourse(page);
+    await singleCoursePage.open();
 
     // redirectIfNotManager() replaces the management route with AssignmentsCard.
-    await expect(page).toHaveURL(/\/course\/\d+\/assignments/);
+    await expect(page).toHaveURL(singleCoursePage.assignmentsUrl);
   });
 
-  test('student does not see management tabs', async ({ page, loginAs }) => {
+  test('student does not see management tabs', async ({ loginAs, singleCoursePage }) => {
     await loginAs('student');
-    await openE2eCourse(page);
+    await singleCoursePage.open();
 
-    await expect(page.getByRole('link', { name: 'People' })).toHaveCount(0);
-    await expect(page.getByRole('link', { name: 'Locations' })).toHaveCount(0);
-    await expect(page.getByRole('link', { name: 'Attendance Events' })).toHaveCount(0);
+    await expect(singleCoursePage.tab('People')).toHaveCount(0);
+    await expect(singleCoursePage.tab('Locations')).toHaveCount(0);
+    await expect(singleCoursePage.tab('Attendance Events')).toHaveCount(0);
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "vue3-google-login": "^2.0.25"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@vitejs/plugin-vue": "^5.2.4",
         "@vue/test-utils": "^2.4.10",
         "clean-webpack-plugin": "^4.0.0",
@@ -801,6 +802,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@popperjs/core": {
@@ -5806,6 +5823,53 @@
         "jsonc-parser": "^3.2.0",
         "mlly": "^1.2.0",
         "pathe": "^1.1.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -10,12 +10,16 @@
     "dev": "webpack serve --config webpack/webpack.dev.js",
     "test": "vitest run",
     "test:watch": "vitest",
+    "e2e": "playwright test",
+    "e2e:headed": "playwright test --headed",
+    "e2e:ui": "playwright test --ui",
     "prod": "webpack --config webpack/webpack.prod.js",
     "heroku-postbuild": "npm run prod"
   },
   "author": "",
   "license": "ISC",
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@vitejs/plugin-vue": "^5.2.4",
     "@vue/test-utils": "^2.4.10",
     "clean-webpack-plugin": "^4.0.0",

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -1,0 +1,48 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Browser-based E2E for the Tyto app. Drives the real Vue SPA served by the
+// Roda backend (API + built assets from dist/) on :9292, against a dedicated
+// RACK_ENV=test database. See .claude/plans/PLAN.test-ui.md.
+//
+// Auth is by cookie injection, not Google OAuth: global-setup.mjs mints a real
+// credential per seeded `@e2e.test` account and writes e2e/.auth/credentials.json;
+// the loginAs() fixture (e2e/fixtures.mjs) sets the 5 session cookies.
+//
+// Prerequisites (handled by `rake spec:e2e`): seed the test DB and build the
+// frontend (`npm run prod`). The webServer block below boots the backend.
+
+const BASE_URL = process.env.E2E_BASE_URL || 'http://localhost:9292';
+
+export default defineConfig({
+  testDir: './e2e',
+  testMatch: '**/*.spec.mjs',
+  globalSetup: './e2e/global-setup.mjs',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: BASE_URL,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // Boot the backend (API + dist/ assets) against the test DB. The DB must
+  // already be seeded and dist/ already built — `rake spec:e2e` does both
+  // before invoking Playwright. Locally we reuse an already-running server.
+  webServer: {
+    command: 'RACK_ENV=test bundle exec puma config.ru -t 1:5 -p 9292',
+    url: BASE_URL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+});


### PR DESCRIPTION
## Summary

Stands up a browser-based end-to-end suite (Playwright) that drives the real Vue app + Roda API in Chromium, exercising the key duties of every system role (admin/creator/member) and per-course enrollment role (owner/instructor/staff/student) so role-gated behavior is regression-protected end to end. The suite is then refactored to a Page Object Model and given a single source of truth for seed-reference data. **33 specs, all green.**

## Plan

**Part 1 — E2E suite**
- [x] Playwright harness (config, Chromium, traces/screenshots, `:9292` webServer)
- [x] Cookie-injection login (`loginAs`) — mints real credentials per seeded account, bypasses Google OAuth
- [x] Multi-role course seed (`@e2e.test` accounts, enrolled `E2E Course`, geo-fenced location, live event)
- [x] Acceptance specs across the role × duty matrix (auth, course list, create, role switcher, manage people, attendance events, geo check-in, assignments, account roles, locations)
- [x] CI job (`e2e-tests` in `ci.yml`) running headless Chromium

**Part 2 — Page Object Model refactor**
- [x] Component objects (`Select`, `RolesDialog`) absorbing the brittle Element Plus selectors
- [x] Page objects per route + `AppShell` + anemic `LoginPage`
- [x] All 9 spec files converted; zero selector/route-literal leakage in specs
- [x] Seed-reference SSOT: one Ruby module feeds both the seed and the specs

## Changes

**Test harness & specs** — Playwright suite under `e2e/`:
- `loginAs(role)` cookie-injection fixture + `global-setup.mjs` credential minting (`generate:e2e_credentials` / `generate:test_credential`).
- 9 spec files covering the role/duty matrix; geo-fence check-in mocks browser position via Playwright `geolocation`.
- Page objects (`e2e/pages/`) and component objects (`e2e/components/`) quarantine all Element Plus internals, component CSS, and route literals out of the specs.

**Backend** — seed + spec support:
- `Tyto::E2EFixtures` — side-effect-free module holding the E2E fixture data; `account_seeds.rb` builds the seed from it.
- `generate:e2e_seed_data` rake task emits that data as JSON; `e2e/seed-data.mjs` imports it so specs and the seeded DB never drift.
- `setup_spec.rb` now redirects every seed-written model (Role/Account/Course/AccountCourse/Location/Event) to its scratch DB, fixing a pre-existing cross-DB FK violation.

### Design notes

- **Auth bypass is intentional.** The session is 5 cookies wrapping an encrypted `{account_id, roles}` credential; tests mint one directly with the `JWT_KEY` and skip Google OAuth entirely (flaky/unusable in CI). The Login.vue → Google flow is deliberately unmodeled (the anemic `LoginPage` documents this).
- **Single source of truth, Ruby-side.** The seed module is the only definition of the E2E course/locations/event/accounts; the JS specs read a JSON projection of it, so a name or coordinate change moves the seeded DB and the specs together.

## Test plan

- [x] E2E (Playwright/Chromium): 33 specs, 0 failures
- [x] Backend (Minitest): 1404 runs, 0 failures, 1 expected skip
- [x] Frontend (Vitest): 3/3
- [x] Full `rake spec:e2e` pipeline green (reset+seed test DB → build → boot backend → run)

> Note: `rake spec:e2e` is opt-in and not part of `rake spec`. A known footgun: run `spec:backend` against a test DB freshly migrated (not one left seeded by a prior `spec:e2e` run), since `spec_helper`'s unordered table-delete trips a FK on FK-linked data. CI runs them as separate jobs with fresh DBs, so it's unaffected.